### PR TITLE
Add portainer stack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Django-based web application for managing equipment maintenance, events, and r
 - **Responsive UI**: Bootstrap-based interface with crispy forms
 - **Filtering & Tables**: Advanced filtering and tabular data views
 - **Media Management**: File and image upload capabilities
+- **Container Management**: Integrated Portainer for Docker stack management and monitoring
 
 ## Prerequisites
 
@@ -107,6 +108,28 @@ docker-compose exec web python manage.py shell
 ```bash
 docker-compose exec db psql -U postgres -d maintenance_dashboard
 ```
+
+### Container Management with Portainer
+
+The stack includes Portainer for easy container management through a web interface:
+
+**Access Portainer:**
+- Development: `http://localhost:9000`
+- Production: `https://localhost:9443`
+
+**First-time setup:**
+1. Navigate to the Portainer URL
+2. Create an admin user (strong password required)
+3. Connect to the local Docker environment
+4. Start managing your containers through the web interface
+
+**Key features:**
+- Visual container management and monitoring
+- Real-time logs and resource usage
+- Stack management through web UI
+- Easy service scaling and configuration updates
+
+For detailed Portainer documentation, see [docs/PORTAINER.md](docs/PORTAINER.md).
 
 ### Production Docker Setup
 
@@ -250,6 +273,7 @@ Access the Django admin interface at `http://localhost:8000/admin/` using the su
 - **Maintenance**: Schedule and track maintenance activities
 - **Events**: Log and monitor maintenance events
 - **Reports**: View maintenance reports and analytics
+- **Container Management**: `http://localhost:9000/` - Portainer web interface for Docker management
 
 ## Project Structure
 
@@ -363,6 +387,18 @@ python manage.py dbshell
    docker-compose down -v
    docker system prune -a --volumes
    docker-compose up --build
+   ```
+
+6. **Portainer access issues**:
+   ```bash
+   # Check if Portainer is running
+   docker-compose ps portainer
+   
+   # View Portainer logs
+   docker-compose logs portainer
+   
+   # Restart Portainer only
+   docker-compose restart portainer
    ```
 
 ### Common Issues (Manual Installation)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,5 +52,12 @@ services:
       - web
     restart: unless-stopped
 
+  portainer:
+    environment:
+      - PORTAINER_HTTP_DISABLED=true  # Force HTTPS in production
+    volumes:
+      - ./ssl:/certs:ro  # SSL certificates for Portainer
+    restart: unless-stopped
+
 volumes:
   postgres_data_prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,22 @@ services:
       redis:
         condition: service_healthy
 
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - portainer_data:/data
+    ports:
+      - "9000:9000"
+      - "9443:9443"
+
 volumes:
   postgres_data:
   static_volume:
   media_volume:
+  portainer_data:

--- a/docs/PORTAINER.md
+++ b/docs/PORTAINER.md
@@ -1,0 +1,386 @@
+# Portainer Stack Management
+
+Portainer is a lightweight management UI that allows you to easily manage your Docker environments. It has been integrated into the Maintenance Dashboard stack to provide an intuitive interface for container management, monitoring, and stack operations.
+
+> **🚀 Quick Start**: If you want to get started immediately, see the [Portainer Quick Start Guide](PORTAINER_QUICKSTART.md) for a step-by-step walkthrough.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Installation & Setup](#installation--setup)
+- [First-Time Configuration](#first-time-configuration)
+- [Accessing Portainer](#accessing-portainer)
+- [Using Portainer with the Maintenance Dashboard](#using-portainer-with-the-maintenance-dashboard)
+- [Common Operations](#common-operations)
+- [Monitoring & Troubleshooting](#monitoring--troubleshooting)
+- [Security Considerations](#security-considerations)
+- [Production Deployment](#production-deployment)
+- [Backup & Restore](#backup--restore)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Portainer provides the following benefits for the Maintenance Dashboard:
+
+- **Visual Container Management**: View and manage all containers in a web-based interface
+- **Stack Management**: Manage Docker Compose stacks through the UI
+- **Real-time Monitoring**: Monitor container health, resources, and logs
+- **Easy Scaling**: Scale services up or down with simple controls
+- **Log Management**: Access container logs without using command line
+- **Resource Monitoring**: View CPU, memory, and network usage
+- **Template Management**: Deploy new stacks from templates
+
+## Installation & Setup
+
+Portainer is automatically included in the Docker Compose configuration. Simply start the stack as usual:
+
+### Development Environment
+
+```bash
+# Start the entire stack including Portainer
+docker-compose up -d
+
+# Or build and start if it's the first time
+docker-compose up --build -d
+```
+
+### Production Environment
+
+```bash
+# Start with production configuration
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+### Verify Portainer is Running
+
+```bash
+# Check if Portainer container is running
+docker-compose ps portainer
+
+# View Portainer logs
+docker-compose logs portainer
+```
+
+## First-Time Configuration
+
+1. **Access Portainer**: Navigate to `http://localhost:9000` (or `https://localhost:9443` for HTTPS)
+
+2. **Create Admin User**: 
+   - On first access, you'll be prompted to create an admin user
+   - Choose a strong password (minimum 12 characters)
+   - Complete the setup wizard
+
+3. **Connect to Docker Environment**:
+   - Select "Docker" as the environment type
+   - Choose "Local" to manage the local Docker environment
+   - Click "Connect"
+
+4. **Verify Setup**:
+   - You should see the dashboard with container statistics
+   - Navigate to "Containers" to see all running containers
+   - Navigate to "Stacks" to see the maintenance dashboard stack
+
+## Accessing Portainer
+
+### URLs
+
+- **Development**: 
+  - HTTP: `http://localhost:9000`
+  - HTTPS: `https://localhost:9443`
+
+- **Production**: 
+  - HTTPS: `https://yourdomain.com:9443` (recommended)
+  - Configure reverse proxy for custom domain
+
+### Default Ports
+
+- **9000**: HTTP interface (development only)
+- **9443**: HTTPS interface (recommended for production)
+
+## Using Portainer with the Maintenance Dashboard
+
+### Viewing the Stack
+
+1. Navigate to **Stacks** in the left sidebar
+2. Find the maintenance dashboard stack (usually named after your directory)
+3. Click on the stack name to view details
+
+### Managing Services
+
+From the stack view, you can:
+- **Start/Stop/Restart** individual services
+- **View logs** for each service
+- **Scale services** (increase/decrease replicas)
+- **Update service configurations**
+
+### Monitoring Containers
+
+1. Go to **Containers** in the left sidebar
+2. View all containers with their status, resource usage, and uptime
+3. Click on any container for detailed information:
+   - Resource usage graphs
+   - Environment variables
+   - Volume mounts
+   - Network settings
+
+## Common Operations
+
+### Restarting Services
+
+1. Navigate to **Stacks** → Your stack
+2. Click on the service you want to restart
+3. Click **Restart** button
+
+Or restart the entire stack:
+1. Go to **Stacks** → Your stack
+2. Click **Stop stack** then **Start stack**
+
+### Viewing Logs
+
+1. Navigate to **Containers**
+2. Click on the container name
+3. Go to **Logs** tab
+4. Use the search and filter options to find specific log entries
+
+### Updating Service Configuration
+
+1. Navigate to **Stacks** → Your stack
+2. Click **Editor** tab
+3. Modify the Docker Compose configuration
+4. Click **Update the stack**
+
+⚠️ **Warning**: Always test configuration changes in development first.
+
+### Scaling Services
+
+1. Navigate to **Services** or go to your stack
+2. Click on the service you want to scale
+3. Adjust the **Replicas** number
+4. Click **Scale** or **Update service**
+
+Common scaling scenarios:
+- Scale `web` service for higher traffic
+- Scale `celery` workers for background processing
+
+### Managing Volumes
+
+1. Navigate to **Volumes** in the left sidebar
+2. View all volumes and their usage
+3. Create backups or inspect volume contents
+
+### Managing Networks
+
+1. Navigate to **Networks** in the left sidebar
+2. View network topology and connected containers
+3. Troubleshoot connectivity issues
+
+## Monitoring & Troubleshooting
+
+### Container Health Monitoring
+
+Portainer provides real-time monitoring:
+
+1. **Dashboard Overview**: Quick stats on containers, images, volumes
+2. **Container Details**: CPU, memory, network, and disk I/O graphs
+3. **Health Checks**: Visual indicators for container health status
+
+### Log Analysis
+
+Effective log monitoring:
+
+1. **Real-time Logs**: Use the log viewer for real-time monitoring
+2. **Log Filtering**: Filter by time range, log level, or search terms
+3. **Download Logs**: Export logs for external analysis
+
+### Resource Usage
+
+Monitor resource consumption:
+
+1. **Container Stats**: View CPU and memory usage per container
+2. **Host Stats**: Overall system resource usage
+3. **Alerts**: Set up notifications for resource thresholds (Portainer Business)
+
+### Common Issues and Solutions
+
+| Issue | Solution |
+|-------|----------|
+| Container not starting | Check logs and environment variables |
+| High memory usage | Scale services or optimize application |
+| Database connection issues | Verify DB container health and network connectivity |
+| Service unavailable | Check port mappings and firewall settings |
+
+## Security Considerations
+
+### Development Environment
+
+- Portainer runs on HTTP (port 9000) for ease of development
+- Use strong admin passwords
+- Limit network access to development machines only
+
+### Production Environment
+
+- **HTTPS Only**: Production setup forces HTTPS (port 9443)
+- **SSL Certificates**: Configure proper SSL certificates
+- **Firewall**: Restrict access to Portainer ports
+- **Regular Updates**: Keep Portainer updated to latest version
+
+### Access Control
+
+1. **User Management**: Create separate users for team members
+2. **Role-Based Access**: Assign appropriate roles (Admin, User, Read-only)
+3. **Team Management**: Organize users into teams with specific permissions
+
+### Security Best Practices
+
+- Enable two-factor authentication (Portainer Business)
+- Regular security audits of user access
+- Monitor login attempts and activities
+- Use environment-specific access controls
+
+## Production Deployment
+
+### SSL Configuration
+
+For production, configure SSL certificates:
+
+1. **Certificate Files**: Place SSL certificates in `./ssl/` directory
+2. **Environment Variables**: Set appropriate SSL environment variables
+3. **Reverse Proxy**: Configure nginx or similar for SSL termination
+
+### Environment Variables
+
+```bash
+# Production environment variables
+PORTAINER_HTTP_DISABLED=true
+PORTAINER_HTTPS_PORT=9443
+PORTAINER_SSL_CERT=/certs/cert.pem
+PORTAINER_SSL_KEY=/certs/key.pem
+```
+
+### Reverse Proxy Setup
+
+Example nginx configuration for Portainer:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name portainer.yourdomain.com;
+    
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+    
+    location / {
+        proxy_pass https://localhost:9443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### High Availability
+
+For high availability setups:
+- Use Portainer Business edition
+- Configure multiple Portainer instances
+- Use external database for Portainer data
+- Implement load balancing
+
+## Backup & Restore
+
+### Portainer Data Backup
+
+```bash
+# Backup Portainer data volume
+docker run --rm -v portainer_data:/data -v $(pwd):/backup busybox tar czf /backup/portainer-backup.tar.gz -C /data .
+
+# Restore Portainer data
+docker run --rm -v portainer_data:/data -v $(pwd):/backup busybox tar xzf /backup/portainer-backup.tar.gz -C /data
+```
+
+### Stack Configuration Backup
+
+1. **Export Stack**: Use Portainer's export feature in Stack → Editor
+2. **Version Control**: Keep docker-compose files in version control
+3. **Environment Variables**: Document and backup environment configurations
+
+### Application Data Backup
+
+Don't forget to backup application data:
+
+```bash
+# Backup PostgreSQL data
+docker-compose exec db pg_dump -U postgres maintenance_dashboard > backup.sql
+
+# Backup media files
+docker run --rm -v maintenance-dashboard_media_volume:/data -v $(pwd):/backup busybox tar czf /backup/media-backup.tar.gz -C /data .
+```
+
+## Troubleshooting
+
+### Portainer Won't Start
+
+1. **Check Docker Socket**: Ensure Docker socket is accessible
+   ```bash
+   ls -la /var/run/docker.sock
+   ```
+
+2. **Port Conflicts**: Verify ports 9000/9443 are not in use
+   ```bash
+   netstat -tlnp | grep -E ':(9000|9443)'
+   ```
+
+3. **Permission Issues**: Check file permissions
+   ```bash
+   docker-compose logs portainer
+   ```
+
+### Cannot Access Portainer UI
+
+1. **Firewall**: Check firewall settings
+2. **Network**: Verify container networking
+3. **SSL Issues**: Check SSL certificate configuration in production
+
+### Stack Management Issues
+
+1. **Compose File Errors**: Validate docker-compose syntax
+2. **Resource Limits**: Check available system resources
+3. **Network Conflicts**: Verify network configurations
+
+### Performance Issues
+
+1. **Resource Allocation**: Monitor container resource usage
+2. **Database Performance**: Check database container health
+3. **Log Rotation**: Implement log rotation to prevent disk space issues
+
+### Getting Help
+
+1. **Portainer Documentation**: https://docs.portainer.io/
+2. **Community Forums**: https://github.com/portainer/portainer/discussions
+3. **Project Issues**: Report bugs to the Maintenance Dashboard repository
+
+## Advanced Features (Portainer Business)
+
+For enhanced capabilities, consider Portainer Business Edition:
+
+- **Role-Based Access Control**: Advanced user and team management
+- **GitOps**: Git integration for stack management
+- **Container Scanning**: Security vulnerability scanning
+- **Logging**: Advanced logging and audit capabilities
+- **Support**: Professional support and SLA
+
+## Integration with CI/CD
+
+Portainer can be integrated with CI/CD pipelines:
+
+1. **API Access**: Use Portainer API for automation
+2. **Webhooks**: Configure webhooks for deployment notifications
+3. **Stack Updates**: Automate stack updates via API
+4. **Environment Promotion**: Promote configurations between environments
+
+## Conclusion
+
+Portainer significantly simplifies Docker container management for the Maintenance Dashboard. It provides a user-friendly interface for both development and production environments, making it easier to monitor, troubleshoot, and manage the application stack.
+
+For additional features and enterprise-grade capabilities, consider upgrading to Portainer Business Edition based on your organization's needs.

--- a/docs/PORTAINER_QUICKSTART.md
+++ b/docs/PORTAINER_QUICKSTART.md
@@ -1,0 +1,170 @@
+# Portainer Quick Start Guide
+
+This guide will get you up and running with Portainer for managing your Maintenance Dashboard containers in just a few minutes.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Maintenance Dashboard project cloned locally
+
+## Step 1: Start the Stack
+
+Start the complete stack including Portainer:
+
+```bash
+# Navigate to your project directory
+cd maintenance-dashboard
+
+# Start all services including Portainer
+docker-compose up -d
+
+# Verify all services are running
+docker-compose ps
+```
+
+## Step 2: Access Portainer
+
+Open your web browser and navigate to:
+- **Development**: [http://localhost:9000](http://localhost:9000)
+- **Production**: [https://localhost:9443](https://localhost:9443)
+
+## Step 3: Initial Setup
+
+### Create Admin User
+1. On first visit, you'll see the "Create the first administrator user" screen
+2. Enter:
+   - **Username**: `admin` (or your preferred username)
+   - **Password**: Choose a strong password (minimum 12 characters)
+3. Click **Create user**
+
+### Connect to Docker
+1. Select **Docker** as the environment type
+2. Choose **Local** to manage the local Docker environment
+3. Click **Connect**
+
+## Step 4: Explore Your Stack
+
+### View All Containers
+1. Click **Containers** in the left sidebar
+2. You'll see all running containers:
+   - `portainer` - Container management UI
+   - `*_web_*` - Django web application
+   - `*_db_*` - PostgreSQL database
+   - `*_redis_*` - Redis cache
+   - `*_celery_*` - Background task worker
+   - `*_celery-beat_*` - Task scheduler
+
+### View Stack Details
+1. Click **Stacks** in the left sidebar
+2. Find your maintenance dashboard stack (usually named after your directory)
+3. Click on the stack name to view:
+   - Service status and health
+   - Resource usage
+   - Configuration details
+
+## Step 5: Common Tasks
+
+### View Container Logs
+1. Go to **Containers**
+2. Click on any container name
+3. Click the **Logs** tab
+4. Use real-time log streaming and filtering
+
+### Restart a Service
+1. From **Containers** or **Stacks** view
+2. Click the container name
+3. Click **Restart**
+
+### Monitor Resource Usage
+1. Click **Dashboard** for overview
+2. Click any container for detailed metrics:
+   - CPU usage
+   - Memory consumption
+   - Network I/O
+   - Disk usage
+
+### Scale Services
+1. Go to **Stacks** → Your stack
+2. Find the service to scale (e.g., `web` or `celery`)
+3. Adjust replica count
+4. Click **Update**
+
+## Step 6: Useful Features
+
+### Quick Actions
+- **Container Terminal**: Access container shell via browser
+- **File Browser**: Browse container filesystem
+- **Inspect**: View detailed container configuration
+- **Stats**: Real-time resource monitoring
+
+### Stack Management
+- **Update Stack**: Modify docker-compose configuration
+- **Duplicate Stack**: Create copies for testing
+- **Export Stack**: Backup stack configuration
+
+## Common URLs Quick Reference
+
+| Service | Development URL | Production URL |
+|---------|----------------|----------------|
+| Maintenance Dashboard | http://localhost:8000 | https://yourdomain.com |
+| Portainer | http://localhost:9000 | https://yourdomain.com:9443 |
+| PostgreSQL | localhost:5432 | (internal only) |
+| Redis | localhost:6379 | (internal only) |
+
+## Troubleshooting
+
+### Portainer Won't Load
+```bash
+# Check if Portainer is running
+docker-compose ps portainer
+
+# View Portainer logs
+docker-compose logs portainer
+
+# Restart Portainer
+docker-compose restart portainer
+```
+
+### Can't See Containers
+1. Ensure you selected the correct Docker environment during setup
+2. Check that Docker daemon is accessible
+3. Verify user has Docker permissions
+
+### Port Conflicts
+If port 9000 or 9443 is already in use:
+1. Stop conflicting services
+2. Or modify ports in `docker-compose.yml`:
+   ```yaml
+   portainer:
+     ports:
+       - "9001:9000"  # Change external port
+       - "9444:9443"  # Change external port
+   ```
+
+## Next Steps
+
+- Read the [complete Portainer documentation](PORTAINER.md)
+- Explore Portainer's advanced features
+- Set up production environment with SSL
+- Configure user access and permissions
+
+## Security Note
+
+For production environments:
+- Use HTTPS only (port 9443)
+- Set strong passwords
+- Configure SSL certificates
+- Restrict network access to trusted IPs
+- Regular security updates
+
+## Getting Help
+
+- [Portainer Documentation](https://docs.portainer.io/)
+- [Maintenance Dashboard Documentation](../README.md)
+- [Full Portainer Guide](PORTAINER.md)
+
+---
+
+**🎉 You're now ready to manage your Maintenance Dashboard with Portainer!**
+
+The web interface makes it easy to monitor, troubleshoot, and manage your Docker containers without using the command line.

--- a/docs/portainer-template.json
+++ b/docs/portainer-template.json
@@ -1,0 +1,88 @@
+{
+  "version": "2",
+  "templates": [
+    {
+      "type": 3,
+      "title": "Maintenance Dashboard",
+      "description": "Complete Django-based maintenance dashboard with PostgreSQL, Redis, Celery, and Portainer",
+      "note": "This template deploys the full Maintenance Dashboard stack including database, cache, web application, background workers, and container management.",
+      "categories": ["Web Applications", "Django", "Maintenance"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/docker-library/docs/master/django/logo.png",
+      "repository": {
+        "url": "https://github.com/your-username/maintenance-dashboard",
+        "stackfile": "docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "SECRET_KEY",
+          "label": "Django Secret Key",
+          "description": "Secret key for Django application (change in production)",
+          "default": "django-insecure-docker-development-key-change-in-production"
+        },
+        {
+          "name": "DEBUG",
+          "label": "Debug Mode",
+          "description": "Enable Django debug mode (set to False in production)",
+          "default": "True",
+          "select": [
+            {
+              "text": "True",
+              "value": "True"
+            },
+            {
+              "text": "False", 
+              "value": "False"
+            }
+          ]
+        },
+        {
+          "name": "DB_PASSWORD",
+          "label": "Database Password",
+          "description": "Password for PostgreSQL database",
+          "default": "postgres"
+        },
+        {
+          "name": "ALLOWED_HOSTS",
+          "label": "Allowed Hosts",
+          "description": "Comma-separated list of allowed hosts",
+          "default": "localhost,127.0.0.1,0.0.0.0"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "title": "Maintenance Dashboard (Production)",
+      "description": "Production-ready Maintenance Dashboard with SSL and Nginx reverse proxy",
+      "note": "This template deploys the production version with nginx reverse proxy and SSL support. Make sure to configure SSL certificates.",
+      "categories": ["Web Applications", "Django", "Production"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/docker-library/docs/master/django/logo.png",
+      "repository": {
+        "url": "https://github.com/your-username/maintenance-dashboard",
+        "stackfile": "docker-compose.yml",
+        "composeFilePathInRepository": "docker-compose.prod.yml"
+      },
+      "env": [
+        {
+          "name": "SECRET_KEY",
+          "label": "Django Secret Key",
+          "description": "Secret key for Django application (REQUIRED - use a strong secret key)",
+          "default": ""
+        },
+        {
+          "name": "DB_PASSWORD",
+          "label": "Database Password", 
+          "description": "Password for PostgreSQL database (REQUIRED - use a strong password)",
+          "default": ""
+        },
+        {
+          "name": "ALLOWED_HOSTS",
+          "label": "Allowed Hosts",
+          "description": "Comma-separated list of allowed hosts (include your domain)",
+          "default": "yourdomain.com,www.yourdomain.com"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add Portainer to the Docker Compose setup and provide comprehensive documentation for web-based container management.

This PR integrates Portainer into the Docker Compose setup, allowing users to manage and monitor the application's containers, stacks, and volumes through an intuitive web interface. It includes detailed documentation (`docs/PORTAINER.md`), a quick start guide (`docs/PORTAINER_QUICKSTART.md`), and a Portainer stack template (`docs/portainer-template.json`) for easy deployment and operation, enhancing the overall developer and operator experience.