### PR TITLE
Fix profile view routing issue

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -234,7 +234,7 @@
                                 <i class="fas fa-user me-1"></i> {{ user.get_full_name|default:user.username }}
                             </a>
                             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
-                                <a class="dropdown-item" href="{% url 'core:profile_view' %}">
+                                <a class="dropdown-item" href="{% url 'core:profile' %}">
                                     <i class="fas fa-user-cog me-1"></i> Profile
                                 </a>
                                 <div class="dropdown-divider"></div>


### PR DESCRIPTION
Fix NoReverseMatch error by correcting the URL name for the profile link in `base.html`.