### PR TITLE
Fix logging import in views

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -9,6 +9,7 @@ from django.core.paginator import Paginator
 from datetime import datetime, timedelta
 import json
 import uuid
+import logging
 from django.views.decorators.csrf import csrf_exempt
 from django.urls import reverse
 


### PR DESCRIPTION
Add missing `import logging` to `events/views.py` to resolve `NameError`.

The `NameError: name 'logging' is not defined` occurred because `logging.getLogger(__name__)` was called without the `logging` module being imported.