### PR TITLE
Troubleshoot network proxy deployment issue

### DIFF
--- a/PROXY_NETWORK_GUIDE.md
+++ b/PROXY_NETWORK_GUIDE.md
@@ -7,14 +7,14 @@ This guide explains how to configure the maintenance dashboard to join an extern
 All Docker Compose files have been updated to support joining an external proxy network. The configuration includes:
 
 - **Internal network**: `maintenance_network` - for communication between services
-- **External network**: `proxy` - for reverse proxy access
+- **External network**: `proxy-network` - for reverse proxy access
 - **Traefik labels** - for automatic service discovery and routing
 
 ## Prerequisites
 
 1. **Create the proxy network** (if it doesn't exist):
    ```bash
-   docker network create proxy
+   docker network create proxy-network
    ```
 
 2. **Configure your environment** (copy `.env.example` to `.env`):
@@ -43,7 +43,7 @@ services:
       - --api.dashboard=true
       - --api.insecure=true
       - --providers.docker=true
-      - --providers.docker.network=proxy
+      - --providers.docker.network=proxy-network
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
@@ -57,10 +57,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./letsencrypt:/letsencrypt
     networks:
-      - proxy
+      - proxy-network
 
 networks:
-  proxy:
+  proxy-network:
     external: true
 ```
 
@@ -99,7 +99,7 @@ Each file includes:
 networks:
   maintenance_network:
     driver: bridge
-  proxy:
+  proxy-network:
     external: true  # Joins existing proxy network
 ```
 
@@ -114,7 +114,7 @@ labels:
   - "traefik.http.routers.maintenance-web.entrypoints=websecure"
   - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
   - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
-  - "traefik.docker.network=proxy"
+  - "traefik.docker.network=proxy-network"
 ```
 
 ## Environment Variables
@@ -126,7 +126,7 @@ Set these in your `.env` file:
 DOMAIN=maintenance.yourdomain.com
 
 # Proxy network name (if different)
-PROXY_NETWORK=proxy
+PROXY_NETWORK=proxy-network
 
 # Traefik configuration
 TRAEFIK_ENABLE=true
@@ -142,7 +142,7 @@ TRAEFIK_SERVICE_PORT=8000
 
 1. **Network not found**:
    ```bash
-   docker network create proxy
+   docker network create proxy-network
    ```
 
 2. **Domain not resolving**:
@@ -160,7 +160,7 @@ TRAEFIK_SERVICE_PORT=8000
 ```bash
 # Check network status
 docker network ls
-docker network inspect proxy
+docker network inspect proxy-network
 
 # Check container logs
 docker-compose logs traefik

--- a/docker-compose.enhanced.yml
+++ b/docker-compose.enhanced.yml
@@ -85,14 +85,14 @@ services:
         condition: service_healthy
     networks:
       - maintenance_network
-      - proxy
+      - proxy-network
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.maintenance-web.rule=Host(`maintenance.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.maintenance-web.entrypoints=websecure"
       - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
       - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
-      - "traefik.docker.network=proxy"
+      - "traefik.docker.network=proxy-network"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/", "||", "exit", "1"]
       interval: 30s
@@ -292,7 +292,7 @@ networks:
       driver: default
       config:
         - subnet: 172.20.0.0/16
-  proxy:
+  proxy-network:
     external: true
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,14 +57,14 @@ services:
         condition: service_healthy
     networks:
       - maintenance_network
-      - proxy
+      - proxy-network
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.maintenance-web.rule=Host(`maintenance.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.maintenance-web.entrypoints=websecure"
       - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
       - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
-      - "traefik.docker.network=proxy"
+      - "traefik.docker.network=proxy-network"
     restart: unless-stopped
 
   celery:
@@ -116,7 +116,7 @@ services:
 networks:
   maintenance_network:
     driver: bridge
-  proxy:
+  proxy-network:
     external: true
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,14 +60,14 @@ services:
         condition: service_healthy
     networks:
       - maintenance_network
-      - proxy
+      - proxy-network
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.maintenance-web.rule=Host(`maintenance.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.maintenance-web.entrypoints=websecure"
       - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
       - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
-      - "traefik.docker.network=proxy"
+      - "traefik.docker.network=proxy-network"
 
   celery:
     build: .
@@ -116,7 +116,7 @@ services:
 networks:
   maintenance_network:
     driver: bridge
-  proxy:
+  proxy-network:
     external: true
 
 volumes:

--- a/portainer-stack-with-image.yml
+++ b/portainer-stack-with-image.yml
@@ -11,6 +11,8 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+    networks:
+      - maintenance_network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -22,6 +24,8 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    networks:
+      - maintenance_network
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -55,6 +59,16 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    networks:
+      - maintenance_network
+      - proxy-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.maintenance-web.rule=Host(`maintenance.${DOMAIN:-localhost}`)"
+      - "traefik.http.routers.maintenance-web.entrypoints=websecure"
+      - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
+      - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
+      - "traefik.docker.network=proxy-network"
     restart: unless-stopped
 
   celery:
@@ -74,6 +88,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    networks:
+      - maintenance_network
     restart: unless-stopped
 
   celery-beat:
@@ -93,7 +109,15 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    networks:
+      - maintenance_network
     restart: unless-stopped
+
+networks:
+  maintenance_network:
+    driver: bridge
+  proxy-network:
+    external: true
 
 volumes:
   postgres_data:

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -65,14 +65,14 @@ services:
         condition: service_healthy
     networks:
       - maintenance_network
-      - proxy
+      - proxy-network
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.maintenance-web.rule=Host(`maintenance.${DOMAIN:-localhost}`)"
       - "traefik.http.routers.maintenance-web.entrypoints=websecure"
       - "traefik.http.routers.maintenance-web.tls.certresolver=letsencrypt"
       - "traefik.http.services.maintenance-web.loadbalancer.server.port=8000"
-      - "traefik.docker.network=proxy"
+      - "traefik.docker.network=proxy-network"
     restart: unless-stopped
 
   celery:
@@ -124,7 +124,7 @@ services:
 networks:
   maintenance_network:
     driver: bridge
-  proxy:
+  proxy-network:
     external: true
 
 volumes:


### PR DESCRIPTION
Update Docker Compose files to correctly use `proxy-network` and add missing network configurations.

This resolves the "network proxy declared as external, but could not be found" error by aligning the Docker Compose files with the user's existing `proxy-network` in Portainer. It also adds the previously missing network and Traefik label configurations to `portainer-stack-with-image.yml`.