### PR TITLE
Fix invalid filter in Django template

### DIFF
--- a/core/templatetags/__init__.py
+++ b/core/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# This file makes templatetags a Python package

--- a/core/templatetags/math_filters.py
+++ b/core/templatetags/math_filters.py
@@ -1,0 +1,35 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def mul(value, arg):
+    """Multiply the value by the argument."""
+    try:
+        return int(value) * int(arg)
+    except (ValueError, TypeError):
+        return 0
+
+@register.filter
+def div(value, arg):
+    """Divide the value by the argument."""
+    try:
+        return int(value) / int(arg)
+    except (ValueError, TypeError, ZeroDivisionError):
+        return 0
+
+@register.filter
+def add_int(value, arg):
+    """Add the argument to the value and return as integer."""
+    try:
+        return int(value) + int(arg)
+    except (ValueError, TypeError):
+        return 0
+
+@register.filter
+def sub(value, arg):
+    """Subtract the argument from the value."""
+    try:
+        return int(value) - int(arg)
+    except (ValueError, TypeError):
+        return 0

--- a/templates/core/location_tree_item.html
+++ b/templates/core/location_tree_item.html
@@ -1,3 +1,4 @@
+{% load math_filters %}
 <div class="location-item" style="margin-left: {{ depth|mul:20 }}px;">
     <div class="location-info">
         <div class="location-name">


### PR DESCRIPTION
Add custom Django math template filters to resolve `TemplateSyntaxError` for the 'mul' filter.

The `mul` filter was used in `location_tree_item.html` for indentation, but it is not a built-in Django filter, causing a `TemplateSyntaxError`.