### PR TITLE
Fix equipment_set prefetch error

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -100,8 +100,8 @@ def dashboard(request):
             parent_location=selected_site,
             is_active=True
         ).select_related('parent_location', 'customer').prefetch_related(
-            Prefetch('equipment_set', queryset=Equipment.objects.select_related('category')),
-            Prefetch('equipment_set__maintenanceactivity_set', 
+            Prefetch('equipment', queryset=Equipment.objects.select_related('category')),
+            Prefetch('equipment__maintenance_activities', 
                     queryset=MaintenanceActivity.objects.select_related('assigned_to'))
         )
         locations = list(locations_queryset)

--- a/events/views.py
+++ b/events/views.py
@@ -31,7 +31,7 @@ def create_maintenance_activity_for_event(event):
         from datetime import datetime, time
         
         # Check if a maintenance activity already exists for this event
-        existing_activity = MaintenanceActivity.objects.filter(calendar_events=event).first()
+        existing_activity = event.maintenance_activity
         
         if existing_activity:
             # Update existing activity


### PR DESCRIPTION
Correct Django model relationship names to resolve `AttributeError`.

The original code used Django's default reverse relationship names (e.g., `_set`) instead of the custom `related_name` attributes defined in the models (e.g., `equipment`, `maintenance_activities`). This caused `AttributeError` when attempting to prefetch or access related objects.