### PR TITLE
Retry database creation on auth failure

### DIFF
--- a/DATABASE_USER_FIX.md
+++ b/DATABASE_USER_FIX.md
@@ -1,0 +1,205 @@
+# Database User Authentication Fix
+
+## 🔍 Problem Analysis
+
+The error you're experiencing is a PostgreSQL authentication failure:
+
+```
+psql: error: connection to server at "db" (172.18.0.3), port 5432 failed: FATAL: password authentication failed for user "maintenance_user"
+```
+
+### Root Cause
+
+The issue occurs because:
+
+1. **Environment Configuration**: Your `env.production` file specifies:
+   ```env
+   DB_USER=maintenance_user
+   DB_PASSWORD=SecureProdPassword2024!
+   ```
+
+2. **PostgreSQL Container**: The PostgreSQL container is initialized with the default `postgres` user, but the `maintenance_user` is never created.
+
+3. **Missing User**: The application tries to connect as `maintenance_user`, but this user doesn't exist in the database.
+
+## 🛠️ Solutions
+
+### Solution 1: Quick Fix (Recommended)
+
+Run the database user fix script inside the database container:
+
+```bash
+# Copy the fix script to the database container
+docker cp fix-database-user-docker.sh maintenance_db:/tmp/
+
+# Execute the script inside the database container
+docker exec -it maintenance_db bash /tmp/fix-database-user-docker.sh
+```
+
+### Solution 2: Manual Database Commands
+
+Connect to the database container and run the commands manually:
+
+```bash
+# Connect to the database container
+docker exec -it maintenance_db bash
+
+# Connect to PostgreSQL as postgres user
+psql -U postgres
+
+# Create the maintenance_user
+CREATE USER maintenance_user WITH PASSWORD 'SecureProdPassword2024!';
+
+# Create the database if it doesn't exist
+CREATE DATABASE maintenance_dashboard_prod;
+
+# Grant privileges
+GRANT ALL PRIVILEGES ON DATABASE maintenance_dashboard_prod TO maintenance_user;
+\c maintenance_dashboard_prod
+GRANT ALL PRIVILEGES ON SCHEMA public TO maintenance_user;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO maintenance_user;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO maintenance_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO maintenance_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO maintenance_user;
+
+# Exit PostgreSQL
+\q
+
+# Test the connection
+PGPASSWORD=SecureProdPassword2024! psql -U maintenance_user -d maintenance_dashboard_prod -c "SELECT 1;"
+```
+
+### Solution 3: Use Default PostgreSQL User (Temporary)
+
+If you need a quick fix to get the application running, you can temporarily modify the environment to use the default `postgres` user:
+
+```bash
+# Edit env.production
+DB_USER=postgres
+DB_PASSWORD=postgres
+```
+
+**Note**: This is not recommended for production as it uses the default credentials.
+
+### Solution 4: Automated Fix Script
+
+Use the external fix script (if you have access to the host):
+
+```bash
+# Set environment variables
+export DB_NAME=maintenance_dashboard_prod
+export DB_USER=maintenance_user
+export DB_PASSWORD=SecureProdPassword2024!
+export DB_HOST=localhost
+export DB_PORT=5432
+
+# Run the fix script
+./fix-database-user.sh
+```
+
+## 🔄 Restart Application
+
+After fixing the database user, restart your application containers:
+
+```bash
+# Restart the web container
+docker-compose restart web
+
+# Or restart all containers
+docker-compose restart
+```
+
+## ✅ Verification
+
+To verify the fix worked:
+
+```bash
+# Test connection from host
+PGPASSWORD=SecureProdPassword2024! psql -h localhost -p 5432 -U maintenance_user -d maintenance_dashboard_prod -c "SELECT 1;"
+
+# Check container logs
+docker-compose logs web
+
+# Test the application
+curl http://localhost:4405/core/health/simple/
+```
+
+## 🛡️ Security Considerations
+
+1. **Strong Passwords**: Use strong, unique passwords for database users
+2. **Limited Privileges**: Consider granting only necessary privileges instead of ALL
+3. **Network Security**: Ensure database is not exposed to external networks
+4. **Environment Variables**: Store sensitive data in environment variables, not in code
+
+## 🔧 Prevention
+
+To prevent this issue in the future:
+
+1. **Database Initialization**: Include user creation in your database initialization scripts
+2. **Docker Compose**: Consider using PostgreSQL initialization scripts
+3. **Documentation**: Document the required database setup steps
+4. **Testing**: Test database connections during the build process
+
+## 📋 PostgreSQL Initialization Script
+
+Create a file `init-db.sql` in your project:
+
+```sql
+-- Create the maintenance_user
+CREATE USER maintenance_user WITH PASSWORD 'SecureProdPassword2024!';
+
+-- Create the database
+CREATE DATABASE maintenance_dashboard_prod;
+
+-- Grant privileges
+GRANT ALL PRIVILEGES ON DATABASE maintenance_dashboard_prod TO maintenance_user;
+```
+
+Then modify your `docker-compose.yml` to include this initialization script:
+
+```yaml
+services:
+  db:
+    image: postgres:15
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+```
+
+## 🆘 Troubleshooting
+
+### Common Issues
+
+1. **Permission Denied**: Ensure the script has execute permissions
+2. **Container Not Found**: Check if the container name matches your setup
+3. **Network Issues**: Verify the database container is accessible
+4. **Password Issues**: Double-check the password matches the environment file
+
+### Debug Commands
+
+```bash
+# Check container status
+docker-compose ps
+
+# View database logs
+docker-compose logs db
+
+# Check network connectivity
+docker exec maintenance_db pg_isready -U postgres
+
+# List all users in PostgreSQL
+docker exec -it maintenance_db psql -U postgres -c "\du"
+```
+
+## 📞 Support
+
+If you continue to experience issues:
+
+1. Check the container logs: `docker-compose logs`
+2. Verify environment variables: `docker-compose config`
+3. Test database connectivity manually
+4. Review the PostgreSQL documentation for your specific version

--- a/fix-database-user-docker.sh
+++ b/fix-database-user-docker.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Fix Database User Authentication Issue (Docker Version)
+# This script creates the maintenance_user in PostgreSQL and grants necessary permissions
+# Designed to be run inside the database container
+
+set -e
+
+# Configuration - Use environment variables with fallbacks
+DB_NAME="${DB_NAME:-maintenance_dashboard_prod}"
+DB_USER="${DB_USER:-maintenance_user}"
+DB_PASSWORD="${DB_PASSWORD:-SecureProdPassword2024!}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if maintenance_user exists
+user_exists() {
+    local result
+    result=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "postgres" -t -c "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'" 2>/dev/null | xargs)
+    [ "$result" = "1" ]
+}
+
+# Function to create maintenance_user
+create_user() {
+    print_status "Creating user '$DB_USER'..."
+    
+    # Create user with password
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "postgres" -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD';" > /dev/null 2>&1; then
+        print_success "User '$DB_USER' created successfully"
+        return 0
+    else
+        print_error "Failed to create user '$DB_USER'"
+        return 1
+    fi
+}
+
+# Function to grant privileges to maintenance_user
+grant_privileges() {
+    print_status "Granting privileges to '$DB_USER'..."
+    
+    # Grant database privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "postgres" -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Database privileges granted"
+    else
+        print_warning "Failed to grant database privileges"
+    fi
+    
+    # Grant schema privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Schema privileges granted"
+    else
+        print_warning "Failed to grant schema privileges"
+    fi
+    
+    # Grant table privileges (for existing tables)
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Table privileges granted"
+    else
+        print_warning "Failed to grant table privileges"
+    fi
+    
+    # Grant sequence privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Sequence privileges granted"
+    else
+        print_warning "Failed to grant sequence privileges"
+    fi
+    
+    # Grant future table privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Future table privileges granted"
+    else
+        print_warning "Failed to grant future table privileges"
+    fi
+    
+    # Grant future sequence privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Future sequence privileges granted"
+    else
+        print_warning "Failed to grant future sequence privileges"
+    fi
+}
+
+# Function to test maintenance_user connection
+test_user_connection() {
+    print_status "Testing connection with '$DB_USER'..."
+    
+    if PGPASSWORD="$DB_PASSWORD" psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1;" > /dev/null 2>&1; then
+        print_success "Connection test successful for '$DB_USER'"
+        return 0
+    else
+        print_error "Connection test failed for '$DB_USER'"
+        return 1
+    fi
+}
+
+# Function to create database if it doesn't exist
+create_database_if_missing() {
+    print_status "Checking if database '$DB_NAME' exists..."
+    
+    # Check if database exists
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "postgres" -t -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1; then
+        print_success "Database '$DB_NAME' already exists"
+        return 0
+    fi
+    
+    # Create database
+    print_status "Creating database '$DB_NAME'..."
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "postgres" -c "CREATE DATABASE $DB_NAME;" > /dev/null 2>&1; then
+        print_success "Database '$DB_NAME' created successfully"
+        return 0
+    else
+        print_error "Failed to create database '$DB_NAME'"
+        return 1
+    fi
+}
+
+# Main function
+main() {
+    print_status "🔧 Starting database user fix (Docker version)..."
+    print_status "Database: $DB_NAME"
+    print_status "User: $DB_USER"
+    
+    # Create database if it doesn't exist
+    if ! create_database_if_missing; then
+        exit 1
+    fi
+    
+    # Check if maintenance_user exists
+    if user_exists; then
+        print_success "User '$DB_USER' already exists"
+    else
+        # Create maintenance_user
+        if ! create_user; then
+            exit 1
+        fi
+    fi
+    
+    # Grant privileges
+    grant_privileges
+    
+    # Test connection
+    if test_user_connection; then
+        print_success "✅ Database user fix completed successfully!"
+        print_status "The maintenance_user is now ready for use."
+    else
+        print_error "❌ Database user fix failed"
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"

--- a/fix-database-user.sh
+++ b/fix-database-user.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Fix Database User Authentication Issue
+# This script creates the maintenance_user in PostgreSQL and grants necessary permissions
+
+set -e
+
+# Configuration - Use environment variables with fallbacks
+DB_NAME="${DB_NAME:-maintenance_dashboard_prod}"
+DB_USER="${DB_USER:-maintenance_user}"
+DB_PASSWORD="${DB_PASSWORD:-SecureProdPassword2024!}"
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to wait for PostgreSQL to be ready
+wait_for_postgres() {
+    local retry_count=0
+    local max_attempts=30
+    
+    print_status "Waiting for PostgreSQL to be ready..."
+    
+    while [ $retry_count -lt $max_attempts ]; do
+        if PGPASSWORD="$POSTGRES_PASSWORD" pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" > /dev/null 2>&1; then
+            print_success "PostgreSQL is ready"
+            return 0
+        fi
+        
+        print_status "PostgreSQL not ready, waiting... (attempt $((retry_count + 1))/$max_attempts)"
+        sleep 2
+        retry_count=$((retry_count + 1))
+    done
+    
+    print_error "PostgreSQL did not become ready within timeout"
+    return 1
+}
+
+# Function to check if maintenance_user exists
+user_exists() {
+    local result
+    result=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "postgres" -t -c "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'" 2>/dev/null | xargs)
+    [ "$result" = "1" ]
+}
+
+# Function to create maintenance_user
+create_user() {
+    print_status "Creating user '$DB_USER'..."
+    
+    # Create user with password
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "postgres" -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD';" > /dev/null 2>&1; then
+        print_success "User '$DB_USER' created successfully"
+        return 0
+    else
+        print_error "Failed to create user '$DB_USER'"
+        return 1
+    fi
+}
+
+# Function to grant privileges to maintenance_user
+grant_privileges() {
+    print_status "Granting privileges to '$DB_USER'..."
+    
+    # Grant database privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "postgres" -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Database privileges granted"
+    else
+        print_warning "Failed to grant database privileges"
+    fi
+    
+    # Grant schema privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Schema privileges granted"
+    else
+        print_warning "Failed to grant schema privileges"
+    fi
+    
+    # Grant table privileges (for existing tables)
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Table privileges granted"
+    else
+        print_warning "Failed to grant table privileges"
+    fi
+    
+    # Grant sequence privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Sequence privileges granted"
+    else
+        print_warning "Failed to grant sequence privileges"
+    fi
+    
+    # Grant future table privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Future table privileges granted"
+    else
+        print_warning "Failed to grant future table privileges"
+    fi
+    
+    # Grant future sequence privileges
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO $DB_USER;" > /dev/null 2>&1; then
+        print_success "Future sequence privileges granted"
+    else
+        print_warning "Failed to grant future sequence privileges"
+    fi
+}
+
+# Function to test maintenance_user connection
+test_user_connection() {
+    print_status "Testing connection with '$DB_USER'..."
+    
+    if PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1;" > /dev/null 2>&1; then
+        print_success "Connection test successful for '$DB_USER'"
+        return 0
+    else
+        print_error "Connection test failed for '$DB_USER'"
+        return 1
+    fi
+}
+
+# Function to create database if it doesn't exist
+create_database_if_missing() {
+    print_status "Checking if database '$DB_NAME' exists..."
+    
+    # Check if database exists
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "postgres" -t -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1; then
+        print_success "Database '$DB_NAME' already exists"
+        return 0
+    fi
+    
+    # Create database
+    print_status "Creating database '$DB_NAME'..."
+    if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "postgres" -c "CREATE DATABASE $DB_NAME;" > /dev/null 2>&1; then
+        print_success "Database '$DB_NAME' created successfully"
+        return 0
+    else
+        print_error "Failed to create database '$DB_NAME'"
+        return 1
+    fi
+}
+
+# Main function
+main() {
+    print_status "🔧 Starting database user fix..."
+    print_status "Database: $DB_NAME"
+    print_status "User: $DB_USER"
+    print_status "Host: $DB_HOST:$DB_PORT"
+    
+    # Wait for PostgreSQL to be ready
+    if ! wait_for_postgres; then
+        exit 1
+    fi
+    
+    # Create database if it doesn't exist
+    if ! create_database_if_missing; then
+        exit 1
+    fi
+    
+    # Check if maintenance_user exists
+    if user_exists; then
+        print_success "User '$DB_USER' already exists"
+    else
+        # Create maintenance_user
+        if ! create_user; then
+            exit 1
+        fi
+    fi
+    
+    # Grant privileges
+    grant_privileges
+    
+    # Test connection
+    if test_user_connection; then
+        print_success "✅ Database user fix completed successfully!"
+        print_status "You can now restart your application containers."
+    else
+        print_error "❌ Database user fix failed"
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
Add scripts and documentation to resolve PostgreSQL 'password authentication failed' errors.

The application was failing to connect to the database because the `maintenance_user` specified in the environment was not created in the PostgreSQL container, leading to repeated authentication failures.