### PR TITLE
Calendar time discrepancy

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -790,25 +790,35 @@ def fetch_unified_events(request):
                     else:
                         bg_color = '#6c757d'
                     
-                    # FullCalendar expects UTC times when timeZone is set - it will convert for display
-                    # So we send UTC times and let FullCalendar handle the timezone conversion
+                    # Convert times to the activity's stored timezone for consistent display
+                    # This ensures the calendar and detail views show the same time
+                    activity_tz_str = getattr(activity, 'timezone', None) or 'America/Chicago'
+                    try:
+                        activity_tz = pytz.timezone(activity_tz_str)
+                    except pytz.exceptions.UnknownTimeZoneError:
+                        activity_tz = pytz.timezone('America/Chicago')
+                    
                     if activity.scheduled_start:
-                        # Ensure timezone-aware, then convert to UTC
+                        # Ensure timezone-aware, then convert to activity's timezone
                         if timezone.is_naive(activity.scheduled_start):
-                            scheduled_start_utc = timezone.make_aware(activity.scheduled_start, pytz.UTC)
+                            scheduled_start_aware = timezone.make_aware(activity.scheduled_start, pytz.UTC)
                         else:
-                            scheduled_start_utc = activity.scheduled_start.astimezone(pytz.UTC)
+                            scheduled_start_aware = activity.scheduled_start
+                        # Convert to activity's timezone for display
+                        scheduled_start_local = scheduled_start_aware.astimezone(activity_tz)
                     else:
-                        scheduled_start_utc = None
+                        scheduled_start_local = None
                     
                     if activity.scheduled_end:
-                        # Ensure timezone-aware, then convert to UTC
+                        # Ensure timezone-aware, then convert to activity's timezone
                         if timezone.is_naive(activity.scheduled_end):
-                            scheduled_end_utc = timezone.make_aware(activity.scheduled_end, pytz.UTC)
+                            scheduled_end_aware = timezone.make_aware(activity.scheduled_end, pytz.UTC)
                         else:
-                            scheduled_end_utc = activity.scheduled_end.astimezone(pytz.UTC)
+                            scheduled_end_aware = activity.scheduled_end
+                        # Convert to activity's timezone for display
+                        scheduled_end_local = scheduled_end_aware.astimezone(activity_tz)
                     else:
-                        scheduled_end_utc = None
+                        scheduled_end_local = None
                     
                     # Get customer ID from equipment location
                     customer_id = None
@@ -820,8 +830,8 @@ def fetch_unified_events(request):
                     calendar_event = {
                         'id': f'activity_{activity.id}',
                         'title': title,
-                        'start': scheduled_start_utc.isoformat() if scheduled_start_utc else None,
-                        'end': scheduled_end_utc.isoformat() if scheduled_end_utc else None,
+                        'start': scheduled_start_local.isoformat() if scheduled_start_local else None,
+                        'end': scheduled_end_local.isoformat() if scheduled_end_local else None,
                         'allDay': False,
                         'backgroundColor': bg_color,
                         'borderColor': '#2d3748',
@@ -839,7 +849,7 @@ def fetch_unified_events(request):
                             'assigned_to': activity.assigned_to.get_full_name() if activity.assigned_to else 'Unassigned',
                             'is_completed': activity.status == 'completed',
                             'status': activity.status,
-                            'timezone': activity.timezone if hasattr(activity, 'timezone') else 'UTC',
+                            'timezone': activity_tz_str,
                         }
                     }
                     

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -2567,7 +2567,7 @@ def get_activity_details(request, activity_id):
         activity_tz = pytz.timezone(activity_timezone_str)
         
         # Convert datetimes to the activity's timezone for display
-        # This ensures the time shown matches what was entered
+        # This ensures the time shown matches what was entered and is consistent with the calendar view
         def convert_to_activity_tz(dt):
             if not dt:
                 return None
@@ -2577,12 +2577,12 @@ def get_activity_details(request, activity_id):
             # If naive, assume UTC and convert to activity's timezone
             return timezone.make_aware(dt, pytz.UTC).astimezone(activity_tz)
         
-        # Send times in UTC - JavaScript will convert to activity's timezone for display
-        # This is the standard approach and avoids timezone confusion
-        scheduled_start_utc = activity.scheduled_start.astimezone(pytz.UTC) if activity.scheduled_start else None
-        scheduled_end_utc = activity.scheduled_end.astimezone(pytz.UTC) if activity.scheduled_end else None
-        actual_start_utc = activity.actual_start.astimezone(pytz.UTC) if activity.actual_start else None
-        actual_end_utc = activity.actual_end.astimezone(pytz.UTC) if activity.actual_end else None
+        # Send times in the activity's timezone for consistent display
+        # This matches the calendar API which also sends times in the activity's timezone
+        scheduled_start_local = convert_to_activity_tz(activity.scheduled_start)
+        scheduled_end_local = convert_to_activity_tz(activity.scheduled_end)
+        actual_start_local = convert_to_activity_tz(activity.actual_start)
+        actual_end_local = convert_to_activity_tz(activity.actual_end)
         
         data = {
             'id': activity.id,
@@ -2600,10 +2600,10 @@ def get_activity_details(request, activity_id):
                 'name': activity.activity_type.name,
                 'category': activity.activity_type.category.name,
             },
-            'scheduled_start': scheduled_start_utc.isoformat() if scheduled_start_utc else None,
-            'scheduled_end': scheduled_end_utc.isoformat() if scheduled_end_utc else None,
-            'actual_start': actual_start_utc.isoformat() if actual_start_utc else None,
-            'actual_end': actual_end_utc.isoformat() if actual_end_utc else None,
+            'scheduled_start': scheduled_start_local.isoformat() if scheduled_start_local else None,
+            'scheduled_end': scheduled_end_local.isoformat() if scheduled_end_local else None,
+            'actual_start': actual_start_local.isoformat() if actual_start_local else None,
+            'actual_end': actual_end_local.isoformat() if actual_end_local else None,
             'timezone': activity.timezone or user_timezone_str,  # Use activity's timezone, fallback to user's timezone
             'timezone_display_name': activity.get_timezone_display_name(),  # Human-readable timezone name from DB
             'assigned_to': activity.assigned_to.username if activity.assigned_to else None,

--- a/templates/events/calendar.html
+++ b/templates/events/calendar.html
@@ -1192,7 +1192,9 @@ function initializeCalendar() {
         var calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: 'dayGridMonth',
         height: 'auto',
-        timeZone: userTimezone, // Use user's profile timezone
+        // Use 'local' timezone - API sends times already converted to each activity's timezone
+        // This ensures calendar display matches the maintenance detail view
+        timeZone: 'local',
         views: {
             dayGridWeek: {
                 dayMaxEvents: 8,


### PR DESCRIPTION
Align timezone display for maintenance activities across calendar and detail views.

Previously, the calendar grid displayed maintenance activity times using the user's profile timezone, while the activity detail page and modal popups used the activity's stored timezone. This led to inconsistencies where the same event showed different times depending on the view. This PR ensures all views consistently display times in the activity's stored timezone by modifying API responses to send times pre-converted to the activity's timezone and configuring FullCalendar to display these times directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-772d1ac7-add8-402c-9e8c-126831dbb6da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-772d1ac7-add8-402c-9e8c-126831dbb6da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

