### PR TITLE
fix(timezone): correct calendar/completion/reminder time handling (#81)

### DIFF
--- a/events/management/commands/fix_calendar_event_times.py
+++ b/events/management/commands/fix_calendar_event_times.py
@@ -1,0 +1,54 @@
+"""
+Rebuild CalendarEvent local time fields from their linked maintenance activities.
+
+Earlier code stored CalendarEvent.event_date/start_time/end_time from the UTC
+instant of the activity instead of the activity's local timezone, so events could
+show on the wrong day/time. This command re-derives those split fields from each
+linked activity via CalendarEvent.set_times_from_activity (idempotent).
+
+Dry-run by default; pass --apply to write changes.
+"""
+
+from django.core.management.base import BaseCommand
+
+from events.models import CalendarEvent
+
+
+class Command(BaseCommand):
+    help = "Rebuild CalendarEvent local time fields from linked maintenance activities."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--apply',
+            action='store_true',
+            help='Persist changes. Without this flag the command only reports (dry-run).',
+        )
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        mode = 'APPLY' if apply_changes else 'DRY-RUN'
+        self.stdout.write(f'Rebuilding CalendarEvent times from activities [{mode}]')
+
+        events = (CalendarEvent.objects
+                  .filter(maintenance_activity__isnull=False)
+                  .select_related('maintenance_activity'))
+
+        checked = 0
+        changed = 0
+        for event in events.iterator():
+            checked += 1
+            old = (event.event_date, event.start_time, event.end_time)
+            event.set_times_from_activity(event.maintenance_activity)
+            new = (event.event_date, event.start_time, event.end_time)
+            if old != new:
+                changed += 1
+                self.stdout.write(
+                    f'  #{event.id}: {old[0]} {old[1]}-{old[2]} -> {new[0]} {new[1]}-{new[2]}'
+                )
+                if apply_changes:
+                    event.save(update_fields=['event_date', 'start_time', 'end_time'])
+
+        summary = f'Checked {checked} linked events; {changed} need(ed) correction.'
+        if not apply_changes and changed:
+            summary += ' Re-run with --apply to persist.'
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/events/models.py
+++ b/events/models.py
@@ -102,6 +102,21 @@ class CalendarEvent(TimeStampedModel):
             self.start_time = None
             self.end_time = None
 
+    def set_times_from_activity(self, activity):
+        """Populate event_date/start_time/end_time from a maintenance activity.
+
+        These split fields are a derived projection of the activity's UTC
+        datetimes expressed in the activity's local timezone; the activity
+        (read via events:fetch_unified_events) remains the source of truth for
+        the live calendar. Reuses MaintenanceActivity.get_scheduled_*_in_timezone.
+        """
+        start_local = activity.get_scheduled_start_in_timezone()
+        if start_local is not None:
+            self.event_date = start_local.date()
+            self.start_time = start_local.time()
+        end_local = activity.get_scheduled_end_in_timezone()
+        self.end_time = end_local.time() if end_local is not None else None
+
     def is_past_due(self):
         """Check if event is past due."""
         from django.utils import timezone

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -15,18 +15,26 @@ logger = logging.getLogger(__name__)
 def send_event_reminders():
     """Send reminders for upcoming events."""
     from .models import CalendarEvent
+    from maintenance.utils import local_date_tomorrow, DEFAULT_ACTIVITY_TIMEZONE
     from datetime import timedelta
-    
-    tomorrow = timezone.now().date() + timedelta(days=1)
-    upcoming_events = CalendarEvent.objects.filter(
-        event_date=tomorrow,
+
+    # event_date is stored in the activity's local timezone, so query a small
+    # window in UTC-date terms and then match the exact local "tomorrow" per event.
+    now = timezone.now()
+    candidate_events = CalendarEvent.objects.filter(
+        event_date__gte=(now - timedelta(days=1)).date(),
+        event_date__lte=(now + timedelta(days=2)).date(),
         is_completed=False,
         assigned_to__isnull=False
-    ).select_related('assigned_to', 'equipment')
-    
+    ).select_related('assigned_to', 'equipment', 'maintenance_activity')
+
     reminders_sent = 0
-    for event in upcoming_events:
+    for event in candidate_events:
         try:
+            event_tz = (event.maintenance_activity.timezone
+                        if event.maintenance_activity else DEFAULT_ACTIVITY_TIMEZONE)
+            if event.event_date != local_date_tomorrow(event_tz):
+                continue
             if event.assigned_to.email:
                 send_mail(
                     subject=f"Event Reminder: {event.title}",
@@ -96,19 +104,19 @@ def generate_maintenance_events():
     
     for activity in activities:
         try:
-            event = CalendarEvent.objects.create(
+            event = CalendarEvent(
                 title=f"Maintenance: {activity.title}",
                 description=activity.description,
                 event_type='maintenance',
                 equipment=activity.equipment,
                 maintenance_activity=activity,
-                event_date=activity.scheduled_start.date(),
-                start_time=activity.scheduled_start.time(),
-                end_time=activity.scheduled_end.time() if activity.scheduled_end else None,
                 assigned_to=activity.assigned_to,
                 priority=activity.priority,
                 created_by_id=1  # System user
             )
+            # Project the activity's UTC times into the activity's local timezone.
+            event.set_times_from_activity(activity)
+            event.save()
             created_count += 1
             logger.info(f"Created calendar event for maintenance activity: {activity.title}")
         except Exception as e:

--- a/events/views.py
+++ b/events/views.py
@@ -64,7 +64,10 @@ def generate_ical_feed(request):
     ical_content += "METHOD:PUBLISH\r\n"
     ical_content += f"X-WR-CALNAME:SOLUNA Maintenance Events\r\n"
     ical_content += f"X-WR-CALDESC:Maintenance and equipment events from SOLUNA Dashboard\r\n"
-    ical_content += f"X-WR-TIMEZONE:UTC\r\n"
+    # event_date/start_time are stored in the activity's local timezone, so DTSTART
+    # below is emitted as floating local time. Do NOT advertise X-WR-TIMEZONE:UTC
+    # (that previously mislabeled local times as UTC). TODO: emit TZID + VTIMEZONE
+    # per event for fully unambiguous cross-client behavior.
     
     for event in events:
         ical_content += "BEGIN:VEVENT\r\n"

--- a/maintenance/forms.py
+++ b/maintenance/forms.py
@@ -310,22 +310,16 @@ class MaintenanceActivityForm(forms.ModelForm):
         scheduled_end = cleaned_data.get('scheduled_end')
         timezone_str = cleaned_data.get('timezone')
         
-        # Handle timezone conversion for datetime-local inputs
-        # Always make datetimes timezone-aware to avoid naive datetime warnings
+        # Handle timezone conversion for datetime-local inputs. The user enters a
+        # wall-clock time in their selected timezone; store it as UTC. When no
+        # timezone is provided, parse_wallclock_to_utc falls back to UTC.
+        from maintenance.utils import parse_wallclock_to_utc
         if scheduled_start:
-            if timezone_str:
-                scheduled_start = self._convert_to_timezone(scheduled_start, timezone_str)
-            elif timezone.is_naive(scheduled_start):
-                # If no timezone provided, assume UTC
-                scheduled_start = timezone.make_aware(scheduled_start, timezone.utc)
+            scheduled_start = parse_wallclock_to_utc(scheduled_start, timezone_str)
             cleaned_data['scheduled_start'] = scheduled_start
-            
+
         if scheduled_end:
-            if timezone_str:
-                scheduled_end = self._convert_to_timezone(scheduled_end, timezone_str)
-            elif timezone.is_naive(scheduled_end):
-                # If no timezone provided, assume UTC
-                scheduled_end = timezone.make_aware(scheduled_end, timezone.utc)
+            scheduled_end = parse_wallclock_to_utc(scheduled_end, timezone_str)
             cleaned_data['scheduled_end'] = scheduled_end
         
         if scheduled_start and scheduled_end:
@@ -381,28 +375,9 @@ class MaintenanceActivityForm(forms.ModelForm):
         Returns:
             A timezone-aware datetime in UTC
         """
-        import pytz
-        from django.utils import timezone as django_timezone
-        
-        try:
-            target_tz = pytz.timezone(timezone_str)
-        except (pytz.exceptions.UnknownTimeZoneError, AttributeError):
-            # Fallback to UTC if timezone is invalid
-            target_tz = pytz.UTC
-        
-        if dt.tzinfo is None:
-            # Naive datetime - interpret as being in the user's selected timezone
-            # Use localize() for proper pytz handling (not make_aware which can have issues)
-            localized_dt = target_tz.localize(dt)
-            # Convert to UTC for storage
-            return localized_dt.astimezone(pytz.UTC)
-        else:
-            # Already timezone-aware
-            # Check if it's already in UTC
-            if dt.tzinfo == pytz.UTC or str(dt.tzinfo) == 'UTC':
-                return dt
-            # Otherwise, convert to UTC for storage
-            return dt.astimezone(pytz.UTC)
+        # Delegate to the shared helper (single source of truth for tz conversion).
+        from maintenance.utils import parse_wallclock_to_utc
+        return parse_wallclock_to_utc(dt, timezone_str)
     
     def _convert_from_utc(self, utc_datetime, timezone_str):
         """Convert UTC datetime to naive datetime in specified timezone for display."""
@@ -544,49 +519,49 @@ class MaintenanceActivityForm(forms.ModelForm):
                     target_date = advance_target_date
                 
                 # Generate all future activities starting from the next occurrence
-                # (skip the first one since it's already created)
-                next_date = instance.scheduled_start.date() + timedelta(days=frequency_days)
+                # (skip the first one since it's already created). Step over LOCAL
+                # dates and keep the seed's local time-of-day, then store UTC, so
+                # occurrences land on the correct calendar day in the activity's tz.
+                from maintenance.utils import generate_activity_title, parse_wallclock_to_utc
+                activity_tz = instance.timezone
+                seed_local = instance.get_scheduled_start_in_timezone()
+                seed_local_date = seed_local.date() if seed_local else instance.scheduled_start.date()
+                seed_local_time = seed_local.time() if seed_local else datetime.min.time()
+                duration_hours = instance.activity_type.estimated_duration_hours or 1
+
+                next_date = seed_local_date + timedelta(days=frequency_days)
                 last_generated_date = None
-                
+
                 while next_date <= target_date:
+                    occurrence_start = parse_wallclock_to_utc(
+                        datetime.combine(next_date, seed_local_time), activity_tz
+                    )
                     # Check if activity already exists for this date
                     existing = MaintenanceActivity.objects.filter(
                         equipment=instance.equipment,
                         activity_type=instance.activity_type,
-                        scheduled_start__date=next_date
+                        scheduled_start__date=occurrence_start.date()
                     ).exists()
-                    
+
                     if not existing:
-                        # Get the time from the original activity, or use a default
-                        start_time = instance.scheduled_start.time() if instance.scheduled_start else datetime.min.time()
-                        
-                        # Create the maintenance activity
                         # Generate title using Dashboard Settings template
-                        from maintenance.utils import generate_activity_title
                         future_activity_title = generate_activity_title(
                             template=None,  # Will use Dashboard Settings template
                             activity_type=instance.activity_type,
                             equipment=instance.equipment,
-                            scheduled_start=timezone.make_aware(
-                                datetime.combine(next_date, start_time)
-                            ),
+                            scheduled_start=occurrence_start,
                             priority=instance.priority,
                             status='scheduled'
                         )
-                        
+
                         future_activity = MaintenanceActivity.objects.create(
                             equipment=instance.equipment,
                             activity_type=instance.activity_type,
                             title=future_activity_title,
                             description=instance.activity_type.description or instance.description,
-                            scheduled_start=timezone.make_aware(
-                                datetime.combine(next_date, start_time)
-                            ),
-                            scheduled_end=timezone.make_aware(
-                                datetime.combine(next_date, start_time)
-                            ) + timedelta(
-                                hours=instance.activity_type.estimated_duration_hours if instance.activity_type.estimated_duration_hours else 1
-                            ),
+                            scheduled_start=occurrence_start,
+                            scheduled_end=occurrence_start + timedelta(hours=duration_hours),
+                            timezone=activity_tz,
                             status='scheduled',
                             priority=instance.priority,
                             assigned_to=instance.assigned_to,
@@ -596,22 +571,22 @@ class MaintenanceActivityForm(forms.ModelForm):
                         # Track the last date we generated an activity for
                         last_generated_date = next_date
                         
-                        # Create corresponding calendar event
+                        # Create corresponding calendar event (times projected into
+                        # the activity's local timezone via set_times_from_activity).
                         try:
                             from events.models import CalendarEvent
-                            CalendarEvent.objects.create(
+                            calendar_event = CalendarEvent(
                                 title=f"Maintenance: {future_activity.title}",
                                 description=future_activity.description,
                                 event_type='maintenance',
                                 equipment=future_activity.equipment,
                                 maintenance_activity=future_activity,
-                                event_date=future_activity.scheduled_start.date(),
-                                start_time=future_activity.scheduled_start.time(),
-                                end_time=future_activity.scheduled_end.time() if future_activity.scheduled_end else None,
                                 assigned_to=future_activity.assigned_to,
                                 priority=future_activity.priority,
                                 created_by=future_activity.created_by
                             )
+                            calendar_event.set_times_from_activity(future_activity)
+                            calendar_event.save()
                         except Exception as e:
                             import logging
                             logger = logging.getLogger(__name__)

--- a/maintenance/models.py
+++ b/maintenance/models.py
@@ -529,32 +529,40 @@ class MaintenanceSchedule(TimeStampedModel):
             ).exists()
             
             if not existing:
-                # Create the maintenance activity
-                # Use make_aware instead of replace to properly handle timezones
-                from datetime import datetime as dt
-                import pytz
-                current_tz = timezone.get_current_timezone()
-                naive_start = dt.combine(next_date, dt.min.time())
-                naive_end = dt.combine(next_date, dt.min.time()) + timedelta(hours=self.activity_type.estimated_duration_hours)
-                
+                # Build the start at a sensible local wall-clock (08:00) in the
+                # activity's timezone, then store UTC. Previously this combined the
+                # due date with 00:00 and made it aware in the server zone (UTC),
+                # so generated activities displayed on the previous local day.
+                from datetime import datetime as dt, time as dt_time
+                from maintenance.utils import (
+                    generate_activity_title,
+                    parse_wallclock_to_utc,
+                    DEFAULT_ACTIVITY_TIMEZONE,
+                )
+                activity_tz = DEFAULT_ACTIVITY_TIMEZONE
+                duration_hours = self.activity_type.estimated_duration_hours or 1
+                naive_start = dt.combine(next_date, dt_time(8, 0))
+                scheduled_start = parse_wallclock_to_utc(naive_start, activity_tz)
+                scheduled_end = scheduled_start + timedelta(hours=duration_hours)
+
                 # Generate title using Dashboard Settings template
-                from maintenance.utils import generate_activity_title
                 activity_title = generate_activity_title(
                     template=None,  # Will use Dashboard Settings template
                     activity_type=self.activity_type,
                     equipment=self.equipment,
-                    scheduled_start=timezone.make_aware(naive_start, current_tz),
+                    scheduled_start=scheduled_start,
                     priority='medium' if self.activity_type.is_mandatory else 'low',
                     status='scheduled'
                 )
-                
+
                 activity = MaintenanceActivity.objects.create(
                     equipment=self.equipment,
                     activity_type=self.activity_type,
                     title=activity_title,
                     description=self.activity_type.description,
-                    scheduled_start=timezone.make_aware(naive_start, current_tz),
-                    scheduled_end=timezone.make_aware(naive_end, current_tz),
+                    scheduled_start=scheduled_start,
+                    scheduled_end=scheduled_end,
+                    timezone=activity_tz,
                     status='scheduled',
                     priority='medium' if self.activity_type.is_mandatory else 'low',
                     created_by=self.created_by,

--- a/maintenance/tasks.py
+++ b/maintenance/tasks.py
@@ -39,25 +39,32 @@ def generate_scheduled_maintenance():
 def send_maintenance_reminders():
     """Send reminders for upcoming maintenance activities."""
     from .models import MaintenanceActivity
+    from .utils import local_date_tomorrow
     from datetime import timedelta
-    
-    tomorrow = timezone.now().date() + timedelta(days=1)
-    upcoming_activities = MaintenanceActivity.objects.filter(
-        scheduled_start__date=tomorrow,
+
+    # scheduled_start is UTC; "tomorrow" must be evaluated in each activity's
+    # local timezone. Query a small UTC window, then match the local date.
+    now = timezone.now()
+    candidate_activities = MaintenanceActivity.objects.filter(
+        scheduled_start__gte=now - timedelta(days=1),
+        scheduled_start__lt=now + timedelta(days=2),
         status='scheduled',
         assigned_to__isnull=False
     ).select_related('assigned_to', 'equipment')
-    
+
     reminders_sent = 0
-    for activity in upcoming_activities:
+    for activity in candidate_activities:
         try:
+            start_local = activity.get_scheduled_start_in_timezone()
+            if not start_local or start_local.date() != local_date_tomorrow(activity.timezone):
+                continue
             if activity.assigned_to.email:
                 send_mail(
                     subject=f"Maintenance Reminder: {activity.title}",
                     message=f"You have a maintenance activity scheduled for tomorrow:\n\n"
                            f"Title: {activity.title}\n"
                            f"Equipment: {activity.equipment.name}\n"
-                           f"Scheduled: {activity.scheduled_start}\n",
+                           f"Scheduled: {start_local.strftime('%Y-%m-%d %I:%M %p')} ({activity.timezone})\n",
                     from_email=settings.DEFAULT_FROM_EMAIL,
                     recipient_list=[activity.assigned_to.email],
                     fail_silently=False,

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -1,9 +1,72 @@
 """
 Utility functions for maintenance app.
+
+Timezone convention (see also CalendarEvent.set_times_from_activity):
+- All DateTimeFields are stored UTC-aware (USE_TZ=True, TIME_ZONE='UTC').
+- ``MaintenanceActivity.timezone`` is the display timezone for that activity.
+- User-entered wall-clock times are interpreted in the activity's timezone and
+  converted to UTC for storage via ``parse_wallclock_to_utc``; display converts
+  the stored UTC instant back to the activity/user timezone.
 """
+
+import pytz
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 from core.models import DashboardSettings
+
+# Fallback timezone for activities/schedules that don't carry an explicit one.
+# Matches MaintenanceActivity.timezone's model default.
+DEFAULT_ACTIVITY_TIMEZONE = 'America/Chicago'
+
+
+def parse_wallclock_to_utc(value, timezone_str):
+    """Interpret a wall-clock time as being in ``timezone_str`` and return it as
+    a UTC-aware datetime for storage.
+
+    - ``value`` may be a naive/aware ``datetime`` or a string from a
+      ``datetime-local`` input (e.g. ``'2026-05-29T19:00'``).
+    - Naive values are localized to ``timezone_str`` (DST-safe via pytz
+      ``localize``); aware values are converted to UTC.
+    - Returns ``None`` when ``value`` is falsy.
+    """
+    if not value:
+        return None
+
+    if isinstance(value, str):
+        parsed = None
+        for fmt in ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M',
+                    '%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M'):
+            try:
+                parsed = datetime.strptime(value, fmt)
+                break
+            except ValueError:
+                continue
+        if parsed is None:
+            from django.utils.dateparse import parse_datetime
+            parsed = parse_datetime(value)
+        if parsed is None:
+            raise ValueError(f"Could not parse datetime string: {value!r}")
+        value = parsed
+
+    try:
+        target_tz = pytz.timezone(timezone_str) if timezone_str else pytz.UTC
+    except Exception:
+        target_tz = pytz.UTC
+
+    if timezone.is_naive(value):
+        # Interpret the wall-clock time as being in the target timezone.
+        return target_tz.localize(value).astimezone(pytz.UTC)
+    return value.astimezone(pytz.UTC)
+
+
+def local_date_tomorrow(timezone_str):
+    """Return the date that is 'tomorrow' in ``timezone_str`` (DST-aware)."""
+    try:
+        tz = pytz.timezone(timezone_str) if timezone_str else pytz.UTC
+    except Exception:
+        tz = pytz.UTC
+    return (timezone.now().astimezone(tz) + timedelta(days=1)).date()
 
 
 def generate_activity_title(template, activity_type=None, equipment=None, scheduled_start=None, priority=None, status=None):

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -3894,35 +3894,28 @@ def change_activity_status(request, activity_id):
             actual_start_str = request.POST.get('actual_start', '').strip()
             actual_end_str = request.POST.get('actual_end', '').strip()
             
+            # Wall-clock times entered by the user are in the activity's timezone;
+            # interpret them there and store UTC (do NOT make_aware in the server
+            # zone, which previously saved e.g. "2pm Central" as "2pm UTC").
+            from maintenance.utils import parse_wallclock_to_utc
+
             if new_status == 'in_progress' or new_status == 'completed':
                 # Use custom start time if provided, otherwise use current time or existing value
                 if actual_start_str:
                     try:
-                        from django.utils.dateparse import parse_datetime
-                        activity.actual_start = parse_datetime(actual_start_str)
-                        if not activity.actual_start:
-                            # Try parsing as local datetime
-                            from datetime import datetime
-                            activity.actual_start = datetime.strptime(actual_start_str, '%Y-%m-%dT%H:%M')
-                            activity.actual_start = timezone.make_aware(activity.actual_start)
+                        activity.actual_start = parse_wallclock_to_utc(actual_start_str, activity.timezone)
                     except (ValueError, TypeError):
                         # If parsing fails, use current time
                         if not activity.actual_start:
                             activity.actual_start = timezone.now()
                 elif not activity.actual_start:
                     activity.actual_start = timezone.now()
-            
+
             if new_status == 'completed':
                 # Use custom end time if provided, otherwise use current time or existing value
                 if actual_end_str:
                     try:
-                        from django.utils.dateparse import parse_datetime
-                        activity.actual_end = parse_datetime(actual_end_str)
-                        if not activity.actual_end:
-                            # Try parsing as local datetime
-                            from datetime import datetime
-                            activity.actual_end = datetime.strptime(actual_end_str, '%Y-%m-%dT%H:%M')
-                            activity.actual_end = timezone.make_aware(activity.actual_end)
+                        activity.actual_end = parse_wallclock_to_utc(actual_end_str, activity.timezone)
                     except (ValueError, TypeError):
                         # If parsing fails, use current time
                         if not activity.actual_end:

--- a/maintenance_dashboard/celery.py
+++ b/maintenance_dashboard/celery.py
@@ -26,9 +26,10 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.conf.worker_disable_rate_limits = False
 app.conf.worker_send_task_events = True
 app.conf.task_send_sent_event = True
-# Disable superuser privileges - workers should not run as root
+# Disable superuser privileges - workers should not run as root.
+# os.geteuid only exists on Unix; guard so imports don't crash on Windows dev.
 import os
-if os.geteuid() == 0:
+if hasattr(os, 'geteuid') and os.geteuid() == 0:
     logging.warning("Celery worker is running as root. This is not recommended for security.")
     # Try to switch to non-root user if available
     try:


### PR DESCRIPTION
## Summary
Fixes **#81** (wrong time on calendar from maintenance activity) and the related reminder/calendar/iCal timezone bugs. PR2 of the multi-PR plan.

### Convention (now documented in `maintenance/utils.py`)
- All `DateTimeField`s stored **UTC-aware**.
- `MaintenanceActivity.timezone` is the **display timezone**.
- User wall-clock input → interpreted in the activity tz → stored UTC.
- `CalendarEvent.event_date/start_time/end_time` are a **local-time projection** of the linked activity (the live calendar reads the activity via `fetch_unified_events`, which was already correct).

### Root causes fixed
1. **Completion flow** (`change_activity_status`): `actual_start/end` from a `datetime-local` input were made aware in the **server zone (UTC)**, so "2pm Central" saved as "2pm UTC". Now parsed in the activity tz. *(primary #81 symptom)*
2. **`generate_next_activity`**: built the start at `00:00` UTC → generated activities displayed on the **previous local day**. Now `08:00` local in the activity tz; also sets the `timezone` field.
3. **CalendarEvent projection** (`events/tasks.py`, recurrence in `forms.py`): stored the UTC instant's date/time. Now uses `CalendarEvent.set_times_from_activity` (local).
4. **Reminders** (`maintenance/tasks.py`, `events/tasks.py`): "tomorrow" computed in UTC → off-by-one near midnight. Now evaluated per-activity in local tz via a UTC window + local-date match.
5. **iCal export**: stopped advertising `X-WR-TIMEZONE:UTC` for what are local-time `DTSTART`s.
6. Dropped deprecated `django.utils.timezone.utc`.

### Shared helpers (single source of truth)
- `parse_wallclock_to_utc(value, tz)` — DST-safe `localize` → UTC (the form's `_convert_to_timezone` now delegates here).
- `local_date_tomorrow(tz)`, `DEFAULT_ACTIVITY_TIMEZONE`.
- `CalendarEvent.set_times_from_activity(activity)`.

### Data fix for existing rows
`python manage.py fix_calendar_event_times` rebuilds already-saved `CalendarEvent` rows from their activities. **Dry-run by default**; pass `--apply` to persist. Safe/idempotent.

> Note: reinterpreting historical `actual_start/actual_end` rows written by the old completion bug is **not** automated here (no reliable "was-buggy" marker) — left as a reviewed follow-up.

## Verification
- `7pm Central` → `00:00Z` (CDT, May) and `01:00Z` (CST, Jan) — DST both ways.
- Already-aware input is converted, not double-shifted.
- `CalendarEvent` projects back to `19:00` local on the correct day.
- `python manage.py check` passes.

## Notes
- Touches `events/views.py` (iCal) and `celery.py` (a one-line `os.geteuid` guard) which the security PR (#97) also touches — different regions / identical change, merges cleanly.
- Frequency math (30/90/365-day approximations) and completion-advances-schedule are intentionally **out of scope** here — that's PR3, which depends on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
