### PR TITLE
feat(ui): mobile-friendly nav, header, and tables

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -385,3 +385,40 @@ body .dark-form .btn-primary:hover {
   color: #e2e8f0;
 }
 /* End System Health Panel Dark Mode Fixes */
+
+/* ===================== Mobile responsiveness ===================== */
+@media (max-width: 768px) {
+  /* Map page: stack the map and legend instead of forcing 70/25 columns */
+  .map-content {
+    flex-direction: column;
+  }
+  #map {
+    width: 100%;
+    height: 320px;
+  }
+  .legend {
+    width: 100%;
+  }
+
+  /* Filter bars: let controls wrap and go full-width instead of overflowing */
+  .equipment-filters,
+  .filters,
+  .filter-bar,
+  .filters-and-legend {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .equipment-filters .form-control,
+  .equipment-filters select,
+  .filters .form-control,
+  .filter-bar .form-control {
+    min-width: 0;
+    width: 100%;
+  }
+
+  /* Dashboard card grid: allow narrower cards on phones */
+  .dashboard-content {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -878,6 +878,84 @@
             color: var(--info-color);
             border-left-color: var(--info-color);
         }
+
+        /* ===================== Mobile responsiveness ===================== */
+        /* Hamburger toggle for the primary nav: hidden on desktop. */
+        .mobile-nav-toggle {
+            display: none;
+            width: 100%;
+            align-items: center;
+            justify-content: space-between;
+            background-color: var(--nav-bg);
+            color: var(--text-color);
+            border: none;
+            border-bottom: 1px solid var(--card-border);
+            padding: 12px 16px;
+            font-size: 1rem;
+            cursor: pointer;
+        }
+
+        @media (max-width: 991.98px) {
+            /* Header: wrap instead of overflowing; trim non-essential bits */
+            .main-header {
+                flex-wrap: wrap;
+                gap: 8px;
+                padding: 10px 12px;
+            }
+            .header-controls {
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+            .version-badge { display: none; }
+            .header-logo { max-height: 32px; }
+            .brand-text { font-size: 1rem; }
+            .site-selector { max-width: 100%; }
+
+            /* Navigation: collapse behind the hamburger and stack vertically */
+            .mobile-nav-toggle { display: flex; }
+            .nav-tabs-custom { padding: 0; }
+            .nav-tabs-custom .nav.nav-tabs {
+                flex-direction: column;
+                align-items: stretch;
+            }
+            .nav-tabs-custom .nav-item { width: 100%; }
+            .nav-tabs-custom .nav-link {
+                padding: 12px 16px;
+                border-bottom: 1px solid var(--card-border);
+            }
+            /* Dropdowns render inline within the collapsed menu */
+            .nav-tabs-custom .dropdown-menu {
+                position: static !important;
+                float: none;
+                width: 100%;
+                border: none;
+                box-shadow: none;
+                padding-left: 24px;
+            }
+
+            /* Tables: wrap text instead of truncating; drop fixed layout */
+            .table { table-layout: auto; }
+            .table td,
+            .table th {
+                white-space: normal;
+                overflow: visible;
+                text-overflow: clip;
+                word-break: break-word;
+            }
+
+            /* Keep dropdowns and containers inside the viewport */
+            .dropdown-menu { max-width: 92vw; }
+            .container, .container-fluid {
+                padding-left: 12px;
+                padding-right: 12px;
+            }
+        }
+
+        @media (max-width: 575.98px) {
+            .brand-text { font-size: 0.9rem; }
+            .main-header .btn,
+            .nav-tabs-custom .nav-link { font-size: 0.9rem; }
+        }
     </style>
 </head>
 <body class="{% if user.is_authenticated and user_profile and user_profile.theme_preference == 'light' %}theme-light{% else %}theme-dark{% endif %}">
@@ -940,7 +1018,12 @@
     </div>
 
     <!-- Navigation Tabs -->
-    <div class="nav-tabs-custom">
+    <button class="mobile-nav-toggle" type="button" data-toggle="collapse" data-target="#primaryNav"
+            aria-controls="primaryNav" aria-expanded="false" aria-label="Toggle navigation menu">
+        <span><i class="fas fa-bars me-1"></i> Menu</span>
+        <i class="fas fa-chevron-down"></i>
+    </button>
+    <div class="nav-tabs-custom collapse d-lg-block" id="primaryNav">
         <ul class="nav nav-tabs border-0">
             <li class="nav-item">
                                  <a class="nav-link {% if request.resolver_match.url_name == 'dashboard' %}active{% endif %}" 


### PR DESCRIPTION
## Summary
Makes the app mobile-friendly via shared fixes in `base.html` + `static/css/custom.css`, so **every page** benefits at once.

Base is `latest` (the dev integration branch) for dev testing first; promotes to `main` later with the rest.

### base.html
- **Nav → hamburger.** Primary nav collapses behind a Menu toggle on screens `< lg` (Bootstrap collapse, already loaded). Items stack vertically; in-menu dropdowns render inline. Desktop unchanged (`d-lg-block`).
- **Header wraps** instead of overflowing; version badge hidden on mobile, logo/brand scaled, site selector full-width.
- **Tables wrap** instead of truncating — dropped `table-layout:fixed` + `white-space:nowrap` under the breakpoint (the #1 cause of unreadable tables on phones).
- Dropdowns/containers constrained to viewport. Added `@media` at 991.98px / 575.98px (base previously had **none**).

### custom.css
- Map page stacks (was fixed 70/25 columns).
- Filter bars wrap full-width.
- Dashboard card grid → single column on phones.

### Verification
- `base.html` parses; `manage.py check` passes. Pure HTML/CSS, no backend changes.
- ⚠️ **Visual check on the dev deploy still needed** — templates can't be fully rendered headless. Recommend eyeballing at 375 / 768 px after this hits dev.

### Follow-ups (per-page, after visual review)
- Calendar filter panel, settings `max-width`, and a few templates with their own `<style>` blocks may want small tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)