### PR TITLE
fix: editable overdue activities + consistent activity-local times

### DIFF
--- a/maintenance/models.py
+++ b/maintenance/models.py
@@ -294,6 +294,30 @@ class MaintenanceActivity(TimeStampedModel):
         except Exception:
             return self.scheduled_end
     
+    def get_actual_start_in_timezone(self, target_timezone=None):
+        """Get actual start time in the specified timezone (defaults to activity tz)."""
+        if not self.actual_start:
+            return None
+        if target_timezone is None:
+            target_timezone = self.timezone
+        try:
+            import pytz
+            return self.actual_start.astimezone(pytz.timezone(target_timezone))
+        except Exception:
+            return self.actual_start
+
+    def get_actual_end_in_timezone(self, target_timezone=None):
+        """Get actual end time in the specified timezone (defaults to activity tz)."""
+        if not self.actual_end:
+            return None
+        if target_timezone is None:
+            target_timezone = self.timezone
+        try:
+            import pytz
+            return self.actual_end.astimezone(pytz.timezone(target_timezone))
+        except Exception:
+            return self.actual_end
+
     def get_timezone_display_name(self):
         """Get human-readable timezone name."""
         timezone_display_names = {

--- a/templates/events/calendar.html
+++ b/templates/events/calendar.html
@@ -1905,8 +1905,9 @@ function displayMaintenanceDetails(activity) {
         window.open(`/maintenance/activities/${activity.id}/`, '_blank');
     };
     
-    // Show/hide action buttons based on status
-    if (activity.status === 'Scheduled' || activity.status === 'Pending') {
+    // Edit is available unless the activity is completed or cancelled (includes
+    // Scheduled, Pending, Overdue, In Progress) — matches the detail page.
+    if (activity.status !== 'Completed' && activity.status !== 'Cancelled') {
         editMaintenanceBtn.style.display = 'inline-block';
         editMaintenanceBtn.onclick = function() {
             window.open(`/maintenance/activities/${activity.id}/edit/`, '_blank');

--- a/templates/maintenance/activity_detail.html
+++ b/templates/maintenance/activity_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load maintenance_filters %}
+{% load tz %}
 
 {% block title %}{{ page_title }}{% endblock %}
 
@@ -63,7 +64,7 @@
                                 <strong>Scheduled Start:</strong>
                                 <span class="ms-2">
                                     {% if activity.scheduled_start %}
-                                        {{ activity.get_scheduled_start_in_timezone|date:"Y-m-d H:i" }}
+                                        {% localtime off %}{{ activity.get_scheduled_start_in_timezone|date:"Y-m-d H:i" }}{% endlocaltime %}
                                         {% if activity.timezone %}
                                             <small class="text-muted">({{ activity.get_timezone_display_name }})</small>
                                         {% endif %}
@@ -76,7 +77,7 @@
                                 <strong>Scheduled End:</strong>
                                 <span class="ms-2">
                                     {% if activity.scheduled_end %}
-                                        {{ activity.get_scheduled_end_in_timezone|date:"Y-m-d H:i" }}
+                                        {% localtime off %}{{ activity.get_scheduled_end_in_timezone|date:"Y-m-d H:i" }}{% endlocaltime %}
                                         {% if activity.timezone %}
                                             <small class="text-muted">({{ activity.get_timezone_display_name }})</small>
                                         {% endif %}
@@ -89,7 +90,7 @@
                             <div class="mb-3">
                                 <strong>Actual Start:</strong>
                                 <span class="ms-2">
-                                    {{ activity.actual_start|date:"Y-m-d H:i" }}
+                                    {% localtime off %}{{ activity.get_actual_start_in_timezone|date:"Y-m-d H:i" }}{% endlocaltime %}
                                     {% if activity.timezone %}
                                         <small class="text-muted">({{ activity.get_timezone_display_name }})</small>
                                     {% endif %}
@@ -100,7 +101,7 @@
                             <div class="mb-3">
                                 <strong>Actual End:</strong>
                                 <span class="ms-2">
-                                    {{ activity.actual_end|date:"Y-m-d H:i" }}
+                                    {% localtime off %}{{ activity.get_actual_end_in_timezone|date:"Y-m-d H:i" }}{% endlocaltime %}
                                     {% if activity.timezone %}
                                         <small class="text-muted">({{ activity.get_timezone_display_name }})</small>
                                     {% endif %}


### PR DESCRIPTION
Two bugs reported from the calendar (dev).

### 1. New activity shows only View/Delete, no Edit
A newly created activity scheduled in the past is auto-marked **Overdue**. The calendar details modal showed **Edit** only for `Scheduled`/`Pending`, while **Delete** included `Overdue` — hence View+Delete but no Edit. Edit now shows for any status except `Completed`/`Cancelled` (matches the maintenance detail page).

### 2. Time differs between the event modal and the maintenance detail page
The detail page used `{{ activity.get_scheduled_start_in_timezone|date }}`, but Django's `date` filter re-converts aware datetimes to the active timezone (UTC) — so it showed `00:00` UTC while the modal showed `19:00` activity-local. Fixed by wrapping the detail-page times in `{% localtime off %}`, and added `get_actual_start/end_in_timezone` so actual times also show activity-local.

### Verification
- Proved: a 7 pm Central activity now renders `2026-05-29 19:00` (was `00:00` UTC), matching the modal.
- Templates parse; `manage.py check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)