### PR TITLE
fix(timezone): edit form shows scheduled times in the activity timezone

### DIFF
--- a/maintenance/forms.py
+++ b/maintenance/forms.py
@@ -657,11 +657,15 @@ class MaintenanceActivityForm(forms.ModelForm):
         if self.instance and self.instance.pk:
             timezone_str = self.instance.timezone
             if timezone_str:
-                # Convert UTC datetimes to the activity's timezone for display
+                # Convert UTC datetimes to the activity's timezone for the
+                # datetime-local fields. NOTE: for a ModelForm bound to an
+                # instance, the widget renders from self.initial (populated from
+                # the instance), NOT self.fields[...].initial — so we must set
+                # self.initial here or the raw UTC value would be shown.
                 if self.instance.scheduled_start:
-                    self.fields['scheduled_start'].initial = self._convert_from_utc(self.instance.scheduled_start, timezone_str)
+                    self.initial['scheduled_start'] = self._convert_from_utc(self.instance.scheduled_start, timezone_str)
                 if self.instance.scheduled_end:
-                    self.fields['scheduled_end'].initial = self._convert_from_utc(self.instance.scheduled_end, timezone_str)
+                    self.initial['scheduled_end'] = self._convert_from_utc(self.instance.scheduled_end, timezone_str)
         
         # Add quick creation options to activity type field
         self.fields['activity_type'].widget.attrs.update({


### PR DESCRIPTION
## Bug
The **Edit Activity** form's `datetime-local` fields showed the raw stored **UTC** wall-clock, not the activity's local time — so the form (e.g. `2:00 PM`) disagreed with the detail page / calendar modal (`8:00 AM CST`) for the same `14:00Z` instant. (Reported on `latest`.)

Worse: the field showed UTC but `clean()` interprets input as the activity timezone, so **saving an unchanged edit shifted the time by the tz offset every time** (drift on every save).

## Root cause
For a ModelForm bound to an instance, the widget renders from `self.initial` (populated from the instance via `model_to_dict`), **not** `self.fields[...].initial`. The UTC→local conversion was written to `self.fields['scheduled_start'].initial`, so Django ignored it and rendered the raw instance value.

## Fix
Write the converted values to `self.initial['scheduled_start'/'scheduled_end']`.

## Verification
Round-trip asserted: `14:00Z` → field shows `08:00` (CST); saving `08:00` → `14:00Z` (no drift). `manage.py check` passes.

> Note: this corrects the display + save round-trip going forward. An activity whose stored instant was already off from a pre-fix save reflects that stored instant (now shown consistently everywhere); re-saving via the corrected form stores the intended time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)