### PR TITLE
fix(timezone): treat form datetime input as wall-clock, not server-UTC

### DIFF
--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -26,8 +26,12 @@ def parse_wallclock_to_utc(value, timezone_str):
 
     - ``value`` may be a naive/aware ``datetime`` or a string from a
       ``datetime-local`` input (e.g. ``'2026-05-29T19:00'``).
-    - Naive values are localized to ``timezone_str`` (DST-safe via pytz
-      ``localize``); aware values are converted to UTC.
+    - The value is treated as a WALL-CLOCK in ``timezone_str``. Any tzinfo already
+      attached is dropped first: under ``USE_TZ`` a Django form ``DateTimeField``
+      makes datetime-local input aware in the server zone (UTC), and that spurious
+      tzinfo must NOT be honored — otherwise "8:00 AM Central" would be stored as
+      8:00 UTC and display as 3:00 AM. The naive wall-clock is then localized
+      (DST-safe via pytz ``localize``) and converted to UTC.
     - Returns ``None`` when ``value`` is falsy.
     """
     if not value:
@@ -54,10 +58,11 @@ def parse_wallclock_to_utc(value, timezone_str):
     except Exception:
         target_tz = pytz.UTC
 
-    if timezone.is_naive(value):
-        # Interpret the wall-clock time as being in the target timezone.
-        return target_tz.localize(value).astimezone(pytz.UTC)
-    return value.astimezone(pytz.UTC)
+    # Drop any tzinfo (see docstring) and treat the components as a wall-clock
+    # in the target timezone.
+    if timezone.is_aware(value):
+        value = value.replace(tzinfo=None)
+    return target_tz.localize(value).astimezone(pytz.UTC)
 
 
 def local_date_tomorrow(timezone_str):


### PR DESCRIPTION
## Bug
Editing + saving an activity shifted its time by the timezone offset: enter **8:00 AM–12:00 PM Central**, it saves and displays (calendar + detail) as **3:00 AM–7:00 AM**.

## Root cause
Under `USE_TZ=True`, Django's form `DateTimeField` makes a `datetime-local` value **aware in the server zone (UTC)**. So `MaintenanceActivityForm.clean()` handed `parse_wallclock_to_utc` an `08:00 UTC` value; its *aware* branch just re-expressed it as UTC (a no-op) and stored `08:00 UTC` instead of `08:00 Central` (→ displays 3:00 AM). PR2's tests only covered **string** inputs (which stay naive), so this path was missed.

## Fix
`parse_wallclock_to_utc` now **always treats its input as a wall-clock** in `timezone_str`: drop any attached tzinfo, then localize. Correct for every caller — datetime-local strings stay naive, model/recurrence pass naive datetimes, and an already-target-tz aware value strips+relocalizes to the **same** instant (no regression).

## Verification
- Form `8:00 AM CDT` → `13:00Z` → displays `8:00 AM`; `2:00 PM CST` → `20:00Z` → `2:00 PM`.
- string / naive / already-Central-aware inputs all consistent.
- `manage.py check` passes.

This pairs with #109 (display): together the edit round-trip (load → edit → save → display) is now correct everywhere, and newly created activities store the intended time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)