### PR TITLE
fix(schedules): delete button + missing detail templates (500s)

### DIFF
--- a/maintenance/views/schedules.py
+++ b/maintenance/views/schedules.py
@@ -211,7 +211,7 @@ def delete_schedule(request, schedule_id):
         schedule_name = f"{schedule.equipment.name} - {schedule.activity_type.name}"
         schedule.delete()
         messages.success(request, f'Maintenance schedule "{schedule_name}" deleted successfully!')
-        return redirect('maintenance:schedules')
+        return redirect('maintenance:schedule_list')
     
     context = {'schedule': schedule}
     return render(request, 'maintenance/delete_schedule.html', context)

--- a/templates/maintenance/category_schedule_detail.html
+++ b/templates/maintenance/category_schedule_detail.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load tz %}
+
+{% block title %}Category Schedule - {{ schedule.equipment_category.name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1 class="h3 mb-0">Category Schedule - {{ schedule.equipment_category.name }}</h1>
+                <div class="btn-group" role="group">
+                    <a href="{% url 'maintenance:edit_category_schedule' schedule.id %}" class="btn btn-secondary">
+                        <i class="fas fa-edit"></i> Edit
+                    </a>
+                    <a href="{% url 'maintenance:category_schedule_list' %}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Back to Category Schedules
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Schedule Information</h5></div>
+                <div class="card-body">
+                    <table class="table table-sm mb-0">
+                        <tr><td><strong>Equipment Category:</strong></td><td>{{ schedule.equipment_category.name }}</td></tr>
+                        <tr><td><strong>Activity Type:</strong></td><td>{{ schedule.activity_type.name }}</td></tr>
+                        <tr><td><strong>Frequency:</strong></td><td>{{ schedule.get_frequency_display }}{% if schedule.frequency == 'custom' %} ({{ schedule.frequency_days }} days){% endif %}</td></tr>
+                        <tr><td><strong>Auto-generate:</strong></td><td>{{ schedule.auto_generate|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Advance Notice:</strong></td><td>{{ schedule.advance_notice_days }} days</td></tr>
+                        <tr><td><strong>Mandatory:</strong></td><td>{{ schedule.is_mandatory|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Allow Override:</strong></td><td>{{ schedule.allow_override|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Default Priority:</strong></td><td>{{ schedule.default_priority|capfirst }}</td></tr>
+                        <tr><td><strong>Active:</strong></td><td>{{ schedule.is_active|yesno:"Yes,No" }}</td></tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Equipment in this Category ({{ equipment_list|length }})</h5></div>
+                <div class="card-body" style="max-height: 280px; overflow-y: auto;">
+                    {% for equipment in equipment_list %}
+                        <div>{{ equipment.name }}{% if equipment.location %} <small class="text-muted">- {{ equipment.location.name }}</small>{% endif %}</div>
+                    {% empty %}
+                        <p class="text-muted mb-0">No active equipment in this category.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header"><h5 class="mb-0">Recent Activities</h5></div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm">
+                            <thead><tr><th>Title</th><th>Equipment</th><th>Status</th><th>Scheduled</th></tr></thead>
+                            <tbody>
+                                {% for activity in recent_activities %}
+                                <tr>
+                                    <td><a href="{% url 'maintenance:activity_detail' activity.id %}">{{ activity.title }}</a></td>
+                                    <td>{{ activity.equipment.name }}</td>
+                                    <td>{{ activity.get_status_display }}</td>
+                                    <td>{% if activity.scheduled_start %}{% localtime off %}{{ activity.get_scheduled_start_in_timezone|date:"M d, Y H:i" }}{% endlocaltime %}{% else %}-{% endif %}</td>
+                                </tr>
+                                {% empty %}
+                                <tr><td colspan="4" class="text-center text-muted">No recent activities</td></tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/maintenance/delete_schedule.html
+++ b/templates/maintenance/delete_schedule.html
@@ -1,0 +1,94 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Delete Schedule{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1 class="h3 mb-0">
+                    <i class="fas fa-trash text-danger me-2"></i>
+                    Delete Maintenance Schedule
+                </h1>
+                <a href="{% url 'maintenance:schedule_detail' schedule.id %}" class="btn btn-secondary">
+                    <i class="fas fa-arrow-left"></i> Back to Schedule
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-8 mx-auto">
+            <div class="card border-danger">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        Confirm Schedule Deletion
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-warning">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        <strong>Warning:</strong> This action cannot be undone. Deleting the
+                        schedule stops future activities from being auto-generated for this
+                        equipment/activity type. Existing activities are not affected.
+                    </div>
+
+                    <h6>Schedule Details:</h6>
+                    <table class="table table-sm">
+                        <tr>
+                            <td><strong>Equipment:</strong></td>
+                            <td>{{ schedule.equipment.name }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Activity Type:</strong></td>
+                            <td>{{ schedule.activity_type.name }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Frequency:</strong></td>
+                            <td>{{ schedule.get_frequency_display }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Start Date:</strong></td>
+                            <td>{{ schedule.start_date|date:"M d, Y" }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Auto-generate:</strong></td>
+                            <td>{{ schedule.auto_generate|yesno:"Yes,No" }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Active:</strong></td>
+                            <td>{{ schedule.is_active|yesno:"Yes,No" }}</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="card-footer">
+                    <form method="post" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-danger">
+                            <i class="fas fa-trash me-1"></i> Yes, Delete Schedule
+                        </button>
+                    </form>
+                    <a href="{% url 'maintenance:schedule_detail' schedule.id %}" class="btn btn-secondary ms-2">
+                        <i class="fas fa-times me-1"></i> Cancel
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+$(document).ready(function() {
+    $('form').on('submit', function(e) {
+        if (!confirm('Are you absolutely sure you want to delete this maintenance schedule? This action cannot be undone.')) {
+            e.preventDefault();
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/templates/maintenance/global_schedule_detail.html
+++ b/templates/maintenance/global_schedule_detail.html
@@ -1,0 +1,86 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load tz %}
+
+{% block title %}Global Schedule - {{ schedule.name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1 class="h3 mb-0">Global Schedule - {{ schedule.name }}</h1>
+                <div class="btn-group" role="group">
+                    <a href="{% url 'maintenance:edit_global_schedule' schedule.id %}" class="btn btn-secondary">
+                        <i class="fas fa-edit"></i> Edit
+                    </a>
+                    <a href="{% url 'maintenance:global_schedule_list' %}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Back to Global Schedules
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Schedule Information</h5></div>
+                <div class="card-body">
+                    <table class="table table-sm mb-0">
+                        <tr><td><strong>Name:</strong></td><td>{{ schedule.name }}</td></tr>
+                        <tr><td><strong>Activity Type:</strong></td><td>{{ schedule.activity_type.name }}</td></tr>
+                        <tr><td><strong>Frequency:</strong></td><td>{{ schedule.get_frequency_display }}{% if schedule.frequency == 'custom' %} ({{ schedule.frequency_days }} days){% endif %}</td></tr>
+                        <tr><td><strong>Auto-generate:</strong></td><td>{{ schedule.auto_generate|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Advance Notice:</strong></td><td>{{ schedule.advance_notice_days }} days</td></tr>
+                        <tr><td><strong>Mandatory:</strong></td><td>{{ schedule.is_mandatory|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Allow Override:</strong></td><td>{{ schedule.allow_override|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Default Priority:</strong></td><td>{{ schedule.default_priority|capfirst }}</td></tr>
+                        <tr><td><strong>Active:</strong></td><td>{{ schedule.is_active|yesno:"Yes,No" }}</td></tr>
+                    </table>
+                    {% if schedule.description %}<hr><p class="mb-0">{{ schedule.description|linebreaks }}</p>{% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Applicable Equipment ({{ equipment_list|length }})</h5></div>
+                <div class="card-body" style="max-height: 280px; overflow-y: auto;">
+                    {% for equipment in equipment_list %}
+                        <div>{{ equipment.name }}{% if equipment.location %} <small class="text-muted">- {{ equipment.location.name }}</small>{% endif %}</div>
+                    {% empty %}
+                        <p class="text-muted mb-0">No active equipment.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header"><h5 class="mb-0">Recent Activities</h5></div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm">
+                            <thead><tr><th>Title</th><th>Equipment</th><th>Status</th><th>Scheduled</th></tr></thead>
+                            <tbody>
+                                {% for activity in recent_activities %}
+                                <tr>
+                                    <td><a href="{% url 'maintenance:activity_detail' activity.id %}">{{ activity.title }}</a></td>
+                                    <td>{{ activity.equipment.name }}</td>
+                                    <td>{{ activity.get_status_display }}</td>
+                                    <td>{% if activity.scheduled_start %}{% localtime off %}{{ activity.get_scheduled_start_in_timezone|date:"M d, Y H:i" }}{% endlocaltime %}{% else %}-{% endif %}</td>
+                                </tr>
+                                {% empty %}
+                                <tr><td colspan="4" class="text-center text-muted">No recent activities</td></tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/maintenance/schedule_detail.html
+++ b/templates/maintenance/schedule_detail.html
@@ -14,6 +14,9 @@
                     <a href="{% url 'maintenance:edit_schedule' schedule.id %}" class="btn btn-secondary">
                         <i class="fas fa-edit"></i> Edit
                     </a>
+                    <a href="{% url 'maintenance:delete_schedule' schedule.id %}" class="btn btn-danger">
+                        <i class="fas fa-trash"></i> Delete
+                    </a>
                     <a href="{% url 'maintenance:schedule_list' %}" class="btn btn-outline-secondary">
                         <i class="fas fa-arrow-left"></i> Back to Schedules
                     </a>

--- a/templates/maintenance/schedule_list.html
+++ b/templates/maintenance/schedule_list.html
@@ -76,6 +76,9 @@
                                             <a href="{% url 'maintenance:edit_schedule' schedule.id %}" class="btn btn-sm btn-outline-secondary">
                                                 <i class="fas fa-edit"></i>
                                             </a>
+                                            <a href="{% url 'maintenance:delete_schedule' schedule.id %}" class="btn btn-sm btn-outline-danger" title="Delete schedule">
+                                                <i class="fas fa-trash"></i>
+                                            </a>
                                         </div>
                                     </td>
                                 </tr>

--- a/templates/maintenance/schedule_override_detail.html
+++ b/templates/maintenance/schedule_override_detail.html
@@ -1,0 +1,83 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load tz %}
+
+{% block title %}Schedule Override - {{ override.equipment.name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1 class="h3 mb-0">Schedule Override - {{ override.equipment.name }}</h1>
+                <div class="btn-group" role="group">
+                    <a href="{% url 'maintenance:edit_schedule_override' override.id %}" class="btn btn-secondary">
+                        <i class="fas fa-edit"></i> Edit
+                    </a>
+                    <a href="{% url 'maintenance:schedule_override_list' %}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Back to Overrides
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Override Information</h5></div>
+                <div class="card-body">
+                    <table class="table table-sm mb-0">
+                        <tr><td><strong>Equipment:</strong></td><td>{{ override.equipment.name }}</td></tr>
+                        <tr><td><strong>Activity Type:</strong></td><td>{{ override.activity_type.name }}</td></tr>
+                        <tr><td><strong>Custom Frequency:</strong></td><td>{{ override.get_custom_frequency_display|default:override.custom_frequency }}{% if override.custom_frequency == 'custom' %} ({{ override.custom_frequency_days }} days){% endif %}</td></tr>
+                        <tr><td><strong>Auto-generate:</strong></td><td>{{ override.auto_generate|yesno:"Yes,No" }}</td></tr>
+                        <tr><td><strong>Advance Notice:</strong></td><td>{{ override.advance_notice_days }} days</td></tr>
+                        <tr><td><strong>Default Priority:</strong></td><td>{{ override.default_priority|capfirst }}</td></tr>
+                        <tr><td><strong>Active:</strong></td><td>{{ override.is_active|yesno:"Yes,No" }}</td></tr>
+                    </table>
+                    {% if override.notes %}<hr><p class="mb-0">{{ override.notes|linebreaks }}</p>{% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header"><h5 class="mb-0">Effective Schedule (for comparison)</h5></div>
+                <div class="card-body">
+                    {% if effective_schedule %}
+                        <p class="mb-0">{{ effective_schedule }}</p>
+                    {% else %}
+                        <p class="text-muted mb-0">No effective base schedule found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header"><h5 class="mb-0">Recent Activities</h5></div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm">
+                            <thead><tr><th>Title</th><th>Status</th><th>Scheduled</th></tr></thead>
+                            <tbody>
+                                {% for activity in recent_activities %}
+                                <tr>
+                                    <td><a href="{% url 'maintenance:activity_detail' activity.id %}">{{ activity.title }}</a></td>
+                                    <td>{{ activity.get_status_display }}</td>
+                                    <td>{% if activity.scheduled_start %}{% localtime off %}{{ activity.get_scheduled_start_in_timezone|date:"M d, Y H:i" }}{% endlocaltime %}{% else %}-{% endif %}</td>
+                                </tr>
+                                {% empty %}
+                                <tr><td colspan="3" class="text-center text-muted">No recent activities</td></tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What
Adds a **Delete** button for maintenance schedules (list + detail) and fixes the delete flow, which was unreachable and broken.

## Bugs fixed
- **No Delete button** on schedule list/detail — added (list row action + detail header).
- **GET 500** — the view rendered `maintenance/delete_schedule.html`, which didn't exist. Created it (confirmation page modeled on `delete_report.html`, with a JS confirm).
- **POST NoReverseMatch** — it redirected to `maintenance:schedules`, a URL name that was removed. Fixed to `maintenance:schedule_list`.

## Verification
Delete URL resolves, confirmation page renders, redirect resolves, templates parse, `manage.py check` passes.

## Related bugs found in this area (NOT in this PR — see PR comment)
Reachable 500s: category/global/override **detail** pages render missing templates; and category/global/override schedules have **no delete** route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)