### PR TITLE
fix(schedules): newly-created schedules don't appear in the schedule list

### DIFF
--- a/maintenance/views/schedules.py
+++ b/maintenance/views/schedules.py
@@ -81,8 +81,13 @@ def add_schedule(request):
         if form.is_valid():
             schedule = form.save(commit=False)
             schedule.created_by = request.user
+            # The add template doesn't render the is_active checkbox, so it would
+            # otherwise post as False (BooleanField) and the new schedule would be
+            # hidden from schedule_list (which filters is_active=True). New
+            # schedules are active by default.
+            schedule.is_active = True
             schedule.save()
-            
+
             messages.success(request, f'Maintenance schedule created successfully!')
             return redirect('maintenance:schedule_detail', schedule_id=schedule.id)
     else:
@@ -473,8 +478,11 @@ def add_schedule_override(request):
         if form.is_valid():
             override = form.save(commit=False)
             override.created_by = request.user
+            # The add template doesn't render is_active; default new overrides to
+            # active so they actually take effect.
+            override.is_active = True
             override.save()
-            
+
             messages.success(request, 'Schedule override created successfully!')
             return redirect('maintenance:schedule_override_list')
     else:


### PR DESCRIPTION
## Bug
Creating a schedule via **Add Schedule** saved it (the detail page showed it) but it never appeared in the **schedule list**.

## Cause
`add_schedule.html` renders the form fields **manually** and omits the `is_active` checkbox. Unchecked/absent checkboxes aren't submitted, so the `BooleanField` cleaned to **False** → the new schedule was saved inactive. `schedule_list` filters `is_active=True`, so it was hidden — while `schedule_detail` (no filter) still showed it.

## Fix
Force `is_active=True` when creating a schedule in `add_schedule`. Applied the same guard to `add_schedule_override` (its add form also omits `is_active`), so new overrides are active and actually take effect.

Checked the analogs: `schedule_override_list` doesn't filter `is_active` (no hidden-from-list bug); category/global schedules have no add flow.

`manage.py check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)