### PR TITLE
feat(maintenance): bulk delete on the activities list

### DIFF
--- a/maintenance/urls.py
+++ b/maintenance/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path('activities/', views.activity_list, name='activity_list'),
     path('activities/add/', views.add_activity, name='add_activity'),
     path('activities/bulk-add/', views.bulk_add_activity, name='bulk_add_activity'),
+    path('activities/bulk-delete/', views.bulk_delete_activities, name='bulk_delete_activities'),
     path('activities/<int:activity_id>/', views.activity_detail, name='activity_detail'),
     path('activities/<int:activity_id>/edit/', views.edit_activity, name='edit_activity'),
     path('activities/<int:activity_id>/complete/', views.complete_activity, name='complete_activity'),

--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -881,6 +881,38 @@ def delete_activity(request, activity_id):
 
 
 @login_required
+def bulk_delete_activities(request):
+    """Delete multiple maintenance activities selected on the activity list."""
+    if request.method != 'POST':
+        return redirect('maintenance:activity_list')
+
+    ids = request.POST.getlist('activity_ids')
+    if not ids:
+        messages.warning(request, 'No activities were selected for deletion.')
+    else:
+        qs = MaintenanceActivity.objects.filter(id__in=ids)
+        count = qs.count()
+        # QuerySet.delete() sends pre_delete per object, so the calendar-event
+        # cleanup signal runs for each deleted activity.
+        qs.delete()
+        try:
+            from core.views import invalidate_dashboard_cache
+            invalidate_dashboard_cache(user_id=request.user.id)
+        except Exception as cache_error:
+            logger.warning(f"Could not invalidate dashboard cache: {cache_error}")
+        messages.success(
+            request,
+            f"Deleted {count} maintenance activit{'y' if count == 1 else 'ies'}."
+        )
+
+    # Return to the same filtered/paginated view the user came from, if safe.
+    next_url = request.POST.get('next')
+    if next_url and next_url.startswith('/maintenance/activities'):
+        return redirect(next_url)
+    return redirect('maintenance:activity_list')
+
+
+@login_required
 def get_activities_data(request):
     """AJAX endpoint to get maintenance activities data."""
     activities = MaintenanceActivity.objects.select_related(
@@ -1426,4 +1458,4 @@ def attach_related_activity(request, activity_id):
     }
     return render(request, 'maintenance/attach_related.html', context)
 
-__all__ = ["maintenance_list", "activity_list", "bulk_add_activity", "activity_detail", "add_activity", "edit_activity", "complete_activity", "overdue_maintenance", "delete_activity", "get_activities_data", "fetch_activities", "get_activity_details", "create_activity_api", "upload_activity_document", "change_activity_status", "attach_related_activity"]
+__all__ = ["maintenance_list", "activity_list", "bulk_add_activity", "activity_detail", "add_activity", "edit_activity", "complete_activity", "overdue_maintenance", "delete_activity", "bulk_delete_activities", "get_activities_data", "fetch_activities", "get_activity_details", "create_activity_api", "upload_activity_document", "change_activity_status", "attach_related_activity"]

--- a/templates/maintenance/activity_list.html
+++ b/templates/maintenance/activity_list.html
@@ -41,10 +41,19 @@
                     </div>
                 </div>
                 <div class="card-body">
+                    <form id="bulkDeleteForm" method="post" action="{% url 'maintenance:bulk_delete_activities' %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                        <div class="mb-3">
+                            <button type="submit" id="bulkDeleteBtn" class="btn btn-danger btn-sm" disabled>
+                                <i class="fas fa-trash"></i> Delete Selected (<span id="bulkSelectedCount">0</span>)
+                            </button>
+                        </div>
                     <div class="table-responsive">
                         <table class="table table-hover">
                             <thead>
                                 <tr>
+                                    <th style="width:32px;"><input type="checkbox" id="bulkSelectAll" title="Select all on this page"></th>
                                     <th>Title</th>
                                     <th>Equipment</th>
                                     <th>Activity Type</th>
@@ -58,6 +67,7 @@
                             <tbody>
                                 {% for activity in page_obj %}
                                 <tr>
+                                    <td><input type="checkbox" class="bulk-select-item" name="activity_ids" value="{{ activity.id }}"></td>
                                     <td>
                                         <a href="{% url 'maintenance:activity_detail' activity.id %}">
                                             {{ activity.title }}
@@ -95,12 +105,13 @@
                                 </tr>
                                 {% empty %}
                                 <tr>
-                                    <td colspan="8" class="text-center">No activities found</td>
+                                    <td colspan="9" class="text-center">No activities found</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
                         </table>
                     </div>
+                    </form>
 
                     {% if page_obj.has_other_pages %}
                     <nav aria-label="Page navigation">
@@ -136,4 +147,39 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var selectAll = document.getElementById('bulkSelectAll');
+    var btn = document.getElementById('bulkDeleteBtn');
+    var countEl = document.getElementById('bulkSelectedCount');
+    var form = document.getElementById('bulkDeleteForm');
+    function items() { return Array.prototype.slice.call(document.querySelectorAll('.bulk-select-item')); }
+    function update() {
+        var all = items();
+        var checked = all.filter(function (c) { return c.checked; }).length;
+        if (countEl) countEl.textContent = checked;
+        if (btn) btn.disabled = checked === 0;
+        if (selectAll) {
+            selectAll.checked = checked > 0 && checked === all.length;
+            selectAll.indeterminate = checked > 0 && checked < all.length;
+        }
+    }
+    if (selectAll) selectAll.addEventListener('change', function () {
+        items().forEach(function (c) { c.checked = selectAll.checked; });
+        update();
+    });
+    items().forEach(function (c) { c.addEventListener('change', update); });
+    if (form) form.addEventListener('submit', function (e) {
+        var n = items().filter(function (c) { return c.checked; }).length;
+        if (n === 0) { e.preventDefault(); return; }
+        if (!confirm('Delete ' + n + ' selected maintenance activit' + (n === 1 ? 'y' : 'ies') + '? This cannot be undone.')) {
+            e.preventDefault();
+        }
+    });
+    update();
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
Adds a **Delete Selected** option to `/maintenance/activities/` (requested).

## What
- Per-row checkboxes + a **select-all** header checkbox (with indeterminate state).
- The list is wrapped in a POST form to a new `bulk_delete_activities` view; the **Delete Selected (N)** button is disabled until ≥1 row is selected and shows the count, with a JS confirm before submit.
- `bulk_delete_activities` deletes the selected activities via a filtered queryset — `QuerySet.delete()` fires `pre_delete`, so the existing signal cleans up linked calendar events — then invalidates the dashboard cache and redirects back to the same filtered/paginated view.

## Notes
- New route `activities/bulk-delete/`; view added to the activities submodule `__all__` so it re-exports from the views package (post-split requirement).
- Deletes only the IDs submitted (current page's selections).

## Verification
`manage.py check` passes; template parses; `bulk_delete_activities` URL resolves and the view is exported from the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)