### PR TITLE
fix(mobile): wide tables scroll horizontally instead of squishing to 1 char

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -933,14 +933,24 @@
                 padding-left: 24px;
             }
 
-            /* Tables: wrap text instead of truncating; drop fixed layout */
-            .table { table-layout: auto; }
+            /* Tables: size to content and scroll horizontally instead of
+               squishing wide tables to ~1 character per column. Single-line
+               cells (no truncation) inside the scrollable .table-responsive. */
+            .table-responsive {
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+            }
+            .table {
+                table-layout: auto;
+                width: auto;
+                min-width: 100%;
+            }
             .table td,
             .table th {
-                white-space: normal;
+                white-space: nowrap;
                 overflow: visible;
                 text-overflow: clip;
-                word-break: break-word;
+                word-break: normal;
             }
 
             /* Keep dropdowns and containers inside the viewport */


### PR DESCRIPTION
## Bug
On mobile, the **equipment list** (and other wide tables) collapsed each column to ~1 character, stacking text vertically (one letter per line).

## Cause
The mobile table CSS (from the responsive pass) forced `white-space: normal` + `word-break: break-word`. With 7 columns competing for a ~360px viewport, that lets the browser shrink each column to its minimum *breakable* width — i.e. one character.

## Fix
Use the standard mobile data-table pattern: **single-line cells** (`white-space: nowrap`, `word-break: normal`, no truncation) with the table sized to its content (`width: auto; min-width: 100%`) inside a horizontally-scrollable `.table-responsive`. Wide tables now scroll sideways and stay readable; narrow tables still fill the width.

## Verification
`base.html` + `equipment_list.html` parse; `manage.py check` passes. (Visual confirm on the dev redeploy at phone width.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)