### PR TITLE
fix(equipment): editing equipment silently deactivates it (hidden from maintenance pickers)

### DIFF
--- a/equipment/management/commands/reactivate_equipment.py
+++ b/equipment/management/commands/reactivate_equipment.py
@@ -1,0 +1,46 @@
+"""
+Recover equipment wrongly deactivated by the edit form bug.
+
+Until fixed, editing an equipment posted no is_active value (the edit template
+didn't render the checkbox), so saving set is_active=False and the equipment
+disappeared from the maintenance pickers. This reactivates equipment that is
+is_active=False but whose operational status is 'active' or 'maintenance'
+(i.e. clearly still in service) — it does NOT touch 'retired'/'inactive' status
+equipment, which may be deactivated on purpose.
+
+Dry-run by default; pass --apply to persist.
+"""
+
+from django.core.management.base import BaseCommand
+
+from equipment.models import Equipment
+
+
+class Command(BaseCommand):
+    help = ("Reactivate equipment wrongly set is_active=False whose status is "
+            "active/maintenance. Dry-run unless --apply.")
+
+    def add_arguments(self, parser):
+        parser.add_argument('--apply', action='store_true',
+                            help='Persist changes (otherwise report only).')
+
+    def handle(self, *args, **options):
+        apply_changes = options['apply']
+        self.stdout.write(f"Reactivate wrongly-deactivated equipment [{'APPLY' if apply_changes else 'DRY-RUN'}]")
+
+        qs = Equipment.objects.filter(is_active=False, status__in=['active', 'maintenance']) \
+            .select_related('location')
+        total = qs.count()
+        for eq in qs.iterator():
+            loc = eq.location.name if eq.location else 'no location'
+            self.stdout.write(f"  {eq.name}  (status={eq.status}, {loc})")
+            if apply_changes:
+                eq.is_active = True
+                eq.save(update_fields=['is_active'])
+
+        summary = f"{total} equipment record(s) would be reactivated."
+        if apply_changes:
+            summary = f"Reactivated {total} equipment record(s)."
+        elif total:
+            summary += " Re-run with --apply to persist."
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/templates/equipment/edit_equipment.html
+++ b/templates/equipment/edit_equipment.html
@@ -81,7 +81,26 @@
                             {{ form.non_field_errors }}
                         </div>
                     {% endif %}
-                    
+
+                    <!-- is_active is NOT part of the configurable-fields list, so it must be
+                         rendered explicitly. Without it the checkbox isn't posted and the
+                         BooleanField saves as False, deactivating the equipment and hiding it
+                         from the maintenance pickers. -->
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <div class="form-check">
+                                {{ form.is_active }}
+                                <label for="{{ form.is_active.id_for_label }}" class="form-check-label ms-1">
+                                    {{ form.is_active.label }}
+                                    <small class="text-muted">(uncheck only to deactivate/hide this equipment)</small>
+                                </label>
+                            </div>
+                            {% if form.is_active.errors %}
+                                <div class="text-danger">{{ form.is_active.errors }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+
                     {% load equipment_filters %}
                     
                     <!-- Basic Information Section -->


### PR DESCRIPTION
## Bug (SSDEV-26 call note)
Not all of a site's equipment shows when creating maintenance **in bulk** or **from the calendar** — "check status."

## Root cause
`edit_equipment.html` renders fields via the **configurable-fields loop**, which does **not** include `is_active`. So editing an equipment (e.g. to change its **status**) posted no `is_active` value → the `BooleanField` saved as **False** → the equipment dropped out of the maintenance pickers (`bulk_add_activity` + calendar both filter `is_active=True`). It still showed on the equipment list (which doesn't filter `is_active`), which is why it looked inconsistent. Same class as the schedule/add bugs.

## Fix
- Render `is_active` **explicitly** on the edit form (outside the configurable-fields loop) so edits preserve it and it's toggleable. (`add_equipment` already rendered it.)
- **Recovery:** `manage.py reactivate_equipment` (dry-run by default, `--apply` to persist) reactivates equipment already wrongly set `is_active=False` whose status is `active`/`maintenance`, leaving genuinely `retired`/`inactive` ones alone.

## Verification
`edit_equipment.html` parses; `is_active` is in the form fields; command registers; `manage.py check` passes.

After deploy, run `reactivate_equipment` (dry-run first) on dev/prod to restore the hidden equipment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)