### PR TITLE
feat(equipment): search-as-you-type on equipment list (SSDEV-26 #4)

### DIFF
--- a/templates/equipment/equipment_list.html
+++ b/templates/equipment/equipment_list.html
@@ -285,9 +285,6 @@
         </div>
         
         <div class="action-buttons">
-            <button type="submit" class="btn btn-primary btn-sm">
-                <i class="fas fa-search me-1"></i> Search
-            </button>
             <a href="{% url 'equipment:equipment_list' %}" class="btn btn-outline-secondary btn-sm">
                 <i class="fas fa-times me-1"></i> Clear
             </a>
@@ -515,6 +512,34 @@ $(document).ready(function() {
     $('#category, #location, #status').on('change', function() {
         $(this).closest('form').submit();
     });
+
+    // Search-as-you-type: debounce the search box so it submits shortly after
+    // the user stops typing (no Search button needed). Server-side filtering +
+    // pagination is unchanged — this just auto-fires the same GET request.
+    var $search = $('#search');
+    var searchTimer = null;
+    $search.on('input', function() {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(function() {
+            $search.closest('form').submit();
+        }, 400);
+    });
+    // Submit immediately on Enter (don't wait for the debounce).
+    $search.on('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            clearTimeout(searchTimer);
+            $(this).closest('form').submit();
+        }
+    });
+    // After the page reloads with a search term, restore focus and put the
+    // cursor at the end so the user can keep typing seamlessly.
+    if ($search.val()) {
+        var el = $search.get(0);
+        el.focus();
+        var len = el.value.length;
+        el.setSelectionRange(len, len);
+    }
 });
 
 // CSV Import confirmation


### PR DESCRIPTION
## SSDEV-26 call item #4
Equipment list search should filter **as you type** — no Search button.

## Change (template-only)
- Removed the **Search** button (kept **Clear**).
- Search box auto-submits ~400ms after typing stops (debounced); **Enter** submits immediately.
- After the page reloads with a term, focus + cursor are restored to the search box so typing continues seamlessly.
- Category/Location/Status already auto-submit on change — unchanged.

Server-side filtering and pagination are untouched; this just auto-fires the existing GET request.

## Verify (dev)
Type in the search box on `/equipment/` → list narrows without clicking Search; cursor stays put; Clear resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)