### PR TITLE
fix(equipment): next-maintenance card, transformer-only DGA, schedules tab

### DIFF
--- a/equipment/views.py
+++ b/equipment/views.py
@@ -405,7 +405,24 @@ def equipment_detail(request, equipment_id):
     open_issues_count = issues.filter(status='open').count()
     in_progress_issues_count = issues.filter(status='in_progress').count()
     resolved_issues_count = issues.filter(status='resolved').count()
-    
+
+    # Next scheduled maintenance = soonest upcoming activity not yet completed or
+    # cancelled. equipment.next_maintenance_date is only refreshed on completion,
+    # so it's empty for equipment that have pending-but-never-completed schedules
+    # (the "Not scheduled" bug). Read the real upcoming activity instead.
+    next_maintenance_activity = (
+        equipment.maintenance_activities
+        .exclude(status__in=['completed', 'cancelled'])
+        .order_by('scheduled_start')
+        .first()
+    )
+
+    # DGA (dissolved gas analysis) only applies to transformers.
+    is_transformer = bool(equipment.category and 'transformer' in equipment.category.name.lower())
+
+    # Recurring schedules configured for this specific piece of equipment.
+    maintenance_schedules = equipment.maintenance_schedules.select_related('activity_type').all()
+
     context = {
         'equipment': equipment,
         'maintenance_status': maintenance_status,
@@ -427,6 +444,9 @@ def equipment_detail(request, equipment_id):
         'open_issues_count': open_issues_count,
         'in_progress_issues_count': in_progress_issues_count,
         'resolved_issues_count': resolved_issues_count,
+        'next_maintenance_activity': next_maintenance_activity,
+        'is_transformer': is_transformer,
+        'maintenance_schedules': maintenance_schedules,
     }
     
     return render(request, 'equipment/equipment_detail.html', context)

--- a/templates/equipment/equipment_detail.html
+++ b/templates/equipment/equipment_detail.html
@@ -77,7 +77,14 @@
         <div class="card">
             <div class="card-body text-center">
                 <h6>Next Maintenance</h6>
-                {% if equipment.next_maintenance_date %}
+                {% if next_maintenance_activity %}
+                    <p class="mb-0">
+                        <a href="{% url 'maintenance:activity_detail' next_maintenance_activity.id %}">
+                            {% localtime off %}{{ next_maintenance_activity.get_scheduled_start_in_timezone|date:"M d, Y" }}{% endlocaltime %}
+                        </a>
+                    </p>
+                    <small class="text-muted">{{ next_maintenance_activity.activity_type.name }}</small>
+                {% elif equipment.next_maintenance_date %}
                     <p class="mb-0">{{ equipment.next_maintenance_date|date:"M d, Y" }}</p>
                 {% else %}
                     <p class="text-muted mb-0">Not scheduled</p>
@@ -85,24 +92,24 @@
             </div>
         </div>
     </div>
+    {% if is_transformer %}
     <div class="col-md-3">
         <div class="card">
             <div class="card-body text-center">
                 <h6>DGA Due Date</h6>
                 {% if equipment.dga_due_date %}
                     <p class="mb-0">{{ equipment.dga_due_date|date:"M d, Y" }}</p>
-                    {% if equipment.category.name|lower == 'transformer' or 'transformer' in equipment.category.name|lower %}
-                        <a href="{% url 'maintenance:add_activity' %}?equipment={{ equipment.id }}&type=dga" 
-                           class="btn btn-sm btn-outline-primary mt-2">
-                            <i class="fas fa-flask"></i> Schedule DGA
-                        </a>
-                    {% endif %}
                 {% else %}
-                    <p class="text-muted mb-0">Not applicable</p>
+                    <p class="text-muted mb-0">Not scheduled</p>
                 {% endif %}
+                <a href="{% url 'maintenance:add_activity' %}?equipment={{ equipment.id }}&type=dga"
+                   class="btn btn-sm btn-outline-primary mt-2">
+                    <i class="fas fa-flask"></i> Schedule DGA
+                </a>
             </div>
         </div>
     </div>
+    {% endif %}
 </div>
 
 <!-- Tabbed Content -->
@@ -119,6 +126,14 @@
                     <li class="nav-item">
                         <a class="nav-link" id="maintenance-tab" data-toggle="tab" href="#maintenance" role="tab">
                             <i class="fas fa-wrench me-1"></i> Maintenance History
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="schedules-tab" data-toggle="tab" href="#schedules" role="tab">
+                            <i class="fas fa-calendar-alt me-1"></i> Schedules
+                            {% if maintenance_schedules %}
+                                <span class="badge badge-secondary">{{ maintenance_schedules|length }}</span>
+                            {% endif %}
                         </a>
                     </li>
                     <li class="nav-item">
@@ -349,7 +364,75 @@
                             </div>
                         {% endif %}
                     </div>
-                    
+
+                    <!-- Schedules Tab -->
+                    <div class="tab-pane fade" id="schedules" role="tabpanel">
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h6 class="mb-0">Maintenance Schedules</h6>
+                            <a href="{% url 'maintenance:add_schedule' %}?equipment={{ equipment.id }}" class="btn btn-sm btn-primary">
+                                <i class="fas fa-plus me-1"></i> Add Schedule
+                            </a>
+                        </div>
+
+                        {% if maintenance_schedules %}
+                            <div class="table-responsive">
+                                <table class="table table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>Activity Type</th>
+                                            <th>Frequency</th>
+                                            <th>Start Date</th>
+                                            <th>Next Due</th>
+                                            <th>Auto-generate</th>
+                                            <th>Status</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for schedule in maintenance_schedules %}
+                                        <tr>
+                                            <td>{{ schedule.activity_type.name }}</td>
+                                            <td>{{ schedule.get_frequency_display }}</td>
+                                            <td>{{ schedule.start_date|date:"M d, Y" }}</td>
+                                            <td>{{ schedule.get_next_due_date|date:"M d, Y"|default:"—" }}</td>
+                                            <td>
+                                                {% if schedule.auto_generate %}
+                                                    <span class="badge badge-success">On</span>
+                                                {% else %}
+                                                    <span class="badge badge-secondary">Off</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if schedule.is_active %}
+                                                    <span class="badge badge-primary">Active</span>
+                                                {% else %}
+                                                    <span class="badge badge-secondary">Inactive</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <a href="{% url 'maintenance:schedule_detail' schedule.id %}" class="btn btn-sm btn-outline-primary" title="View">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                                <a href="{% url 'maintenance:edit_schedule' schedule.id %}" class="btn btn-sm btn-outline-secondary" title="Edit">
+                                                    <i class="fas fa-edit"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <div class="text-center py-4">
+                                <i class="fas fa-calendar-alt fa-3x text-muted mb-3"></i>
+                                <p class="text-muted">No recurring schedules configured for this equipment</p>
+                                <a href="{% url 'maintenance:add_schedule' %}?equipment={{ equipment.id }}" class="btn btn-primary">
+                                    <i class="fas fa-plus me-1"></i> Add First Schedule
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+
                     <!-- Components Tab -->
                     <div class="tab-pane fade" id="components" role="tabpanel">
                         <div class="d-flex justify-content-between align-items-center mb-3">


### PR DESCRIPTION
Three equipment-detail page fixes.

### 1. "Next Maintenance" showed "Not scheduled" despite pending activities
The card read `equipment.next_maintenance_date` — a stored field only refreshed when an activity is **completed**, so it stayed empty for equipment with pending-but-never-completed schedules. The view now finds the **soonest upcoming activity** (status not completed/cancelled) and the card shows its date + activity type (linked), falling back to the stored field, then "Not scheduled".

### 2. DGA Due Date only for transformers
Previously the DGA card rendered on **every** equipment ("Not applicable"). It now renders only when the category is a transformer (`is_transformer`, computed in the view). The Schedule-DGA button is always available on transformers.

### 3. Schedules visible per equipment
New **Schedules** tab listing the recurring `MaintenanceSchedule` rows configured for this equipment — Activity Type, Frequency, Start, Next Due, Auto-generate, Status — with view/edit links and an Add Schedule action.

## Verify (dev)
- Equipment with a pending activity → Next Maintenance shows that date + type, not "Not scheduled".
- Non-transformer → no DGA card; transformer → DGA card + Schedule DGA button.
- Schedules tab lists the equipment's schedules (or an empty state with Add Schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)