### PR TITLE
fix(issues): create-maintenance-from-issue timezone required error

### DIFF
--- a/equipment/views.py
+++ b/equipment/views.py
@@ -2546,9 +2546,10 @@ def create_maintenance_from_issue(request, equipment_id, issue_id):
     """Create a corrective maintenance activity from an equipment issue."""
     from maintenance.models import MaintenanceActivityType, ActivityTypeCategory
     from maintenance.forms import MaintenanceActivityForm
+    from maintenance.utils import DEFAULT_ACTIVITY_TIMEZONE
     from django.utils import timezone
     from datetime import timedelta
-    
+
     equipment = get_object_or_404(Equipment, id=equipment_id)
     issue = get_object_or_404(EquipmentIssue, id=issue_id, equipment=equipment)
     
@@ -2590,6 +2591,7 @@ def create_maintenance_from_issue(request, equipment_id, issue_id):
             'status': 'pending',
             'scheduled_start': timezone.now(),
             'scheduled_end': timezone.now() + timedelta(hours=2),
+            'timezone': DEFAULT_ACTIVITY_TIMEZONE,
         }
         
         form = MaintenanceActivityForm(initial=initial_data, request=request)

--- a/templates/equipment/create_maintenance_from_issue_modal.html
+++ b/templates/equipment/create_maintenance_from_issue_modal.html
@@ -42,11 +42,14 @@
     </div>
     
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-4">
             {{ form.scheduled_start|as_crispy_field }}
         </div>
-        <div class="col-md-6">
+        <div class="col-md-4">
             {{ form.scheduled_end|as_crispy_field }}
+        </div>
+        <div class="col-md-4">
+            {{ form.timezone|as_crispy_field }}
         </div>
     </div>
 </form>


### PR DESCRIPTION
## Bug
Clicking **Create Activity** on an issue → submitting the modal failed with:
```
{"timezone":["This field is required."]}
```

## Cause
`create_maintenance_from_issue_modal.html` rendered every `MaintenanceActivityForm` field **except** the required `timezone` field, so the POST carried no timezone. (Same recurring class as the schedule/equipment manual-form bugs — a manually-rendered template dropping a required field.)

## Fix
- Render `form.timezone` in the modal (next to scheduled start/end, now a 3-column row).
- Seed initial timezone with `DEFAULT_ACTIVITY_TIMEZONE` (America/Chicago) in the view.

## Verify (dev)
Equipment → Issues → **Create Activity** → modal shows a Timezone selector → submit creates the corrective activity (no 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)