### PR TITLE
feat(map): Phase 2 — read-only facility floor-plan render

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -43,111 +43,179 @@ from django.utils import timezone
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
 
 
+def _auto_grid(count, area_x, area_y, area_w, area_h, pad):
+    """Lay `count` items out in a centered grid within the given area.
+    Returns a list of (x, y, w, h) rectangles in canvas coordinates."""
+    import math
+    rects = []
+    if count <= 0:
+        return rects
+    cols = max(1, int(math.ceil(math.sqrt(count))))
+    rows = max(1, int(math.ceil(count / cols)))
+    cell_w = (area_w - pad * (cols + 1)) / cols
+    cell_h = (area_h - pad * (rows + 1)) / rows
+    cell_w = max(cell_w, 1)
+    cell_h = max(cell_h, 1)
+    for i in range(count):
+        r, c = divmod(i, cols)
+        x = area_x + pad + c * (cell_w + pad)
+        y = area_y + pad + r * (cell_h + pad)
+        rects.append((round(x, 1), round(y, 1), round(cell_w, 1), round(cell_h, 1)))
+    return rects
+
+
+def _equipment_health(status, open_issues, has_critical_issue, maint):
+    """Reduce a piece of equipment to one of five facility-map health levels."""
+    if has_critical_issue or maint == 'overdue':
+        return 'critical'
+    if open_issues > 0 or maint == 'due':
+        return 'warning'
+    if status == 'maintenance':
+        return 'maintenance'
+    if status == 'active':
+        return 'ok'
+    return 'idle'
+
+
+def _build_site_layout(site):
+    """Build the facility floor-plan data for one site: POD zones with the
+    equipment placed inside, color-coded by status / open issues / maintenance.
+    Saved layout_* coordinates are used when present; otherwise an auto-grid is
+    computed so the map is useful before anything has been hand-placed."""
+    from equipment.models import Equipment, EquipmentIssue
+    from core.utils import get_all_descendant_location_ids
+
+    canvas_w = site.layout_width or 1280
+    canvas_h = site.layout_height or 800
+
+    # Direct children of the site are the top-level zones (PODs/containers).
+    pods = sorted(
+        Location.objects.filter(parent_location=site, is_active=True),
+        key=lambda l: natural_sort_key(l.name),
+    )
+
+    # All equipment under the site (active), with the per-equipment overlays.
+    site_loc_ids = get_all_descendant_location_ids(site, include_inactive=True)
+    equipment = list(
+        Equipment.objects.filter(location_id__in=site_loc_ids, is_active=True)
+        .select_related('location', 'category')
+    )
+    eq_ids = [e.id for e in equipment]
+
+    # Open-issue counts (+ critical flag) per equipment.
+    issues_by_eq = {}
+    for row in (EquipmentIssue.objects
+                .filter(equipment_id__in=eq_ids, status__in=['open', 'in_progress'])
+                .values('equipment')
+                .annotate(total=Count('id'), crit=Count('id', filter=Q(severity='critical')))):
+        issues_by_eq[row['equipment']] = (row['total'], row['crit'])
+
+    # Maintenance flags per equipment.
+    now = timezone.now()
+    soon = now + timedelta(days=14)
+    overdue_ids = set(MaintenanceActivity.objects
+                      .filter(equipment_id__in=eq_ids, status='overdue')
+                      .values_list('equipment_id', flat=True))
+    due_ids = set(MaintenanceActivity.objects
+                  .filter(equipment_id__in=eq_ids, status__in=['scheduled', 'pending'],
+                          scheduled_start__lte=soon)
+                  .values_list('equipment_id', flat=True))
+
+    # Which top-level POD does each equipment belong to? (itself or an ancestor
+    # that is a direct child of the site).
+    pod_id_set = {p.id for p in pods}
+    eq_by_pod = {p.id: [] for p in pods}
+    unzoned = []
+    for e in equipment:
+        loc = e.location
+        owner = None
+        while loc is not None:
+            if loc.id in pod_id_set:
+                owner = loc.id
+                break
+            loc = loc.parent_location
+        (eq_by_pod[owner] if owner else unzoned).append(e)
+
+    def eq_payload(e):
+        total, crit = issues_by_eq.get(e.id, (0, 0))
+        maint = 'overdue' if e.id in overdue_ids else ('due' if e.id in due_ids else 'ok')
+        health = _equipment_health(e.status, total, crit > 0, maint)
+        tip = [e.name, f"Status: {e.get_status_display()}"]
+        if total:
+            tip.append(f"{total} open issue{'s' if total != 1 else ''}" + (f" ({crit} critical)" if crit else ""))
+        if maint == 'overdue':
+            tip.append("Maintenance overdue")
+        elif maint == 'due':
+            tip.append("Maintenance due soon")
+        return {
+            'id': e.id, 'name': e.name, 'health': health,
+            'status': e.status, 'open_issues': total, 'maint': maint,
+            'tooltip': " • ".join(tip),
+            'x': e.layout_x, 'y': e.layout_y, 'w': e.layout_width, 'h': e.layout_height,
+        }
+
+    # Auto-grid the PODs across the canvas (used where saved coords are absent).
+    pod_rects = _auto_grid(len(pods), 0, 0, canvas_w, canvas_h, 24)
+    pods_payload = []
+    for idx, pod in enumerate(pods):
+        ax, ay, aw, ah = pod_rects[idx] if idx < len(pod_rects) else (0, 0, 200, 150)
+        px = pod.layout_x if pod.layout_x is not None else ax
+        py = pod.layout_y if pod.layout_y is not None else ay
+        pw = pod.layout_width or aw
+        ph = pod.layout_height or ah
+
+        members = eq_by_pod.get(pod.id, [])
+        # Inner area for equipment (leave room for the zone header).
+        inner = _auto_grid(len(members), px, py + 30, pw, ph - 38, 8)
+        eq_list = []
+        for j, e in enumerate(members):
+            payload = eq_payload(e)
+            if payload['x'] is None and j < len(inner):
+                payload['x'], payload['y'], payload['w'], payload['h'] = inner[j]
+            eq_list.append(payload)
+
+        counts = {'critical': 0, 'warning': 0, 'maintenance': 0, 'ok': 0, 'idle': 0}
+        for eq in eq_list:
+            counts[eq['health']] += 1
+
+        pods_payload.append({
+            'id': pod.id, 'name': pod.name,
+            'x': round(px, 1), 'y': round(py, 1), 'w': round(pw, 1), 'h': round(ph, 1),
+            'equipment': eq_list, 'counts': counts,
+        })
+
+    return {
+        'site': {'id': site.id, 'name': site.name, 'width': canvas_w, 'height': canvas_h},
+        'pods': pods_payload,
+        'unzoned': [eq_payload(e) for e in unzoned],
+        'equipment_total': len(equipment),
+    }
+
+
 @login_required
 def map_view(request):
-    """Map view showing customer-specific equipment with connections."""
-    from equipment.models import EquipmentConnection
-    import json
-    
-    # Get selected customer from request or show all
-    selected_customer_id = request.GET.get('customer_id', 'all')
-    
-    customers = Customer.objects.filter(is_active=True).order_by('name')
-    
-    # Build customer-specific maps
-    customer_maps = []
-    
-    if selected_customer_id == 'all':
-        # Show all customers
-        customer_list = customers
-    else:
-        # Show specific customer
-        try:
-            customer_list = [customers.get(id=selected_customer_id)]
-        except Customer.DoesNotExist:
-            customer_list = customers
-            selected_customer_id = 'all'
-    
-    for customer in customer_list:
-        # Get all locations for this customer (sites and sub-locations)
-        customer_locations = Location.objects.filter(
-            Q(customer=customer) | Q(parent_location__customer=customer),
-            is_active=True
-        ).select_related('parent_location', 'customer')
-        
-        # Get all equipment at these locations
-        customer_equipment = Equipment.objects.filter(
-            location__in=customer_locations,
-            is_active=True
-        ).select_related('location', 'category')
-        
-        if not customer_equipment.exists():
-            continue
-        
-        # Get equipment IDs for this customer
-        equipment_ids = list(customer_equipment.values_list('id', flat=True))
-        
-        # Get connections between this customer's equipment
-        customer_connections = EquipmentConnection.objects.filter(
-            upstream_equipment__id__in=equipment_ids,
-            downstream_equipment__id__in=equipment_ids,
-            is_active=True
-        ).select_related('upstream_equipment', 'downstream_equipment')
-        
-        # Build connection data for JavaScript
-        connection_data = []
-        for conn in customer_connections:
-            connection_data.append({
-                'id': conn.id,
-                'upstream_id': conn.upstream_equipment.id,
-                'downstream_id': conn.downstream_equipment.id,
-                'connection_type': conn.connection_type,
-                'is_critical': conn.is_critical,
-            })
-        
-        # Build equipment data with effective status
-        equipment_data = []
-        for equip in customer_equipment:
-            effective_status = equip.get_effective_status()
-            equipment_data.append({
-                'id': equip.id,
-                'name': equip.name,
-                'location_id': equip.location.id if equip.location else None,
-                'location_name': equip.location.name if equip.location else 'Unknown',
-                'status': equip.status,
-                'effective_status': effective_status,
-                'is_cascade_offline': effective_status == 'cascade_offline',
-            })
-        
-        # Group locations by site
-        sites = customer_locations.filter(is_site=True)
-        location_groups = {}
-        for site in sites:
-            location_groups[site] = customer_locations.filter(parent_location=site)
-        
-        # Add independent locations (no parent)
-        independent_locations = customer_locations.filter(parent_location=None, is_site=False)
-        if independent_locations.exists():
-            location_groups[None] = independent_locations
-        
-        customer_maps.append({
-            'customer': customer,
-            'locations': customer_locations,
-            'location_groups': location_groups,
-            'equipment': customer_equipment,
-            'connections': customer_connections,
-            'connections_json': json.dumps(connection_data),
-            'equipment_json': json.dumps(equipment_data),
-        })
-    
-    # Get all equipment for connection manager dropdowns
-    all_equipment = Equipment.objects.filter(is_active=True).select_related('location', 'category')
-    
+    """Per-site facility floor-plan map: POD/container zones with equipment placed
+    inside, color-coded by status / open issues / maintenance-due. Honors the
+    global site selector; falls back to an auto-grid where nothing is hand-placed."""
+    sites = sorted(
+        Location.objects.filter(is_site=True, is_active=True),
+        key=lambda s: natural_sort_key(s.name),
+    )
+
+    selected_site_id = request.GET.get('site_id') or request.session.get('selected_site_id')
+    selected_site = None
+    if selected_site_id and selected_site_id != 'all':
+        selected_site = next((s for s in sites if str(s.id) == str(selected_site_id)), None)
+    if selected_site is None and sites:
+        selected_site = sites[0]
+
+    site_layout = _build_site_layout(selected_site) if selected_site else None
+
     context = {
-        'customer_maps': customer_maps,
-        'customers': customers,
-        'selected_customer_id': selected_customer_id,
-        'all_equipment': all_equipment,
+        'sites': sites,
+        'selected_site': selected_site,
+        'selected_site_id': str(selected_site.id) if selected_site else '',
+        'site_layout_json': json.dumps(site_layout) if site_layout else 'null',
     }
     return render(request, 'core/map.html', context)
 

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -1,778 +1,186 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Map - Equipment Dependency Diagram{% endblock %}
+{% block title %}Facility Map - Maintenance Dashboard{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Map</li>
+{% endblock %}
 
 {% block extra_css %}
 <style>
-.map-container {
-    background-color: #1a2238;
-    min-height: 100vh;
-    color: white;
-    padding: 20px;
-}
+.map-header { background-color: #2d3748; border-bottom: 1px solid #4a5568; padding: 15px 20px; margin-bottom: 20px; }
+.map-controls { display: flex; align-items: center; gap: 15px; flex-wrap: wrap; }
+.map-controls label { color: #e2e8f0; font-size: 14px; font-weight: 500; margin: 0; white-space: nowrap; }
+.map-select { background-color: #1a2238; color: #fff; border: 1px solid #4a5568; border-radius: 6px; padding: 6px 12px; font-size: 14px; min-width: 200px; }
+.map-legend { display: flex; gap: 16px; flex-wrap: wrap; margin-left: auto; }
+.legend-item { display: flex; align-items: center; gap: 6px; color: #cbd5e0; font-size: 12px; }
+.legend-swatch { width: 14px; height: 14px; border-radius: 3px; display: inline-block; }
+.lg-critical { background:#f56565; } .lg-warning { background:#ed8936; } .lg-maintenance { background:#4299e1; }
+.lg-ok { background:#48bb78; } .lg-idle { background:#718096; }
 
-.map-header {
-    background-color: #0f1419;
-    padding: 15px 20px;
-    border-radius: 8px;
-    margin-bottom: 20px;
-    border-bottom: 1px solid #2d3748;
-}
+#canvasWrap { position: relative; width: 100%; overflow: hidden; background:#1a2238;
+    background-image: linear-gradient(#2a3550 1px, transparent 1px), linear-gradient(90deg, #2a3550 1px, transparent 1px);
+    background-size: 40px 40px; border: 1px solid #4a5568; border-radius: 8px; }
+#facilityCanvas { position: absolute; top: 0; left: 0; transform-origin: top left; }
 
-.customer-map-section {
-    background-color: #2d3748;
-    border-radius: 12px;
-    padding: 20px;
-    margin-bottom: 30px;
-    border: 2px solid var(--primary-color, #4299e1);
-}
+.pod-zone { position: absolute; border: 1px solid #5a6987; border-radius: 8px;
+    background: rgba(45,55,72,0.55); box-sizing: border-box; }
+.pod-header { position: absolute; top: 0; left: 0; right: 0; height: 26px; padding: 4px 8px;
+    font-size: 12px; font-weight: 600; color: #e2e8f0; border-bottom: 1px solid #4a5568;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pod-header .pod-counts { float: right; font-weight: 400; color: #a0aec0; }
 
-.customer-map-header {
-    background-color: #0f1419;
-    padding: 15px;
-    border-radius: 8px;
-    margin-bottom: 15px;
-    border-left: 4px solid var(--primary-color, #4299e1);
-}
+.eq-box { position: absolute; border-radius: 5px; box-sizing: border-box; cursor: pointer;
+    border: 2px solid; padding: 3px 5px; font-size: 11px; line-height: 1.15; color: #fff;
+    overflow: hidden; display: flex; align-items: center; justify-content: center; text-align: center; }
+.eq-box:hover { filter: brightness(1.18); outline: 2px solid #fff; }
+.eq-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.eq-critical { background:#9b2c2c; border-color:#f56565; }
+.eq-warning { background:#9c4221; border-color:#ed8936; }
+.eq-maintenance { background:#2c5282; border-color:#4299e1; }
+.eq-ok { background:#276749; border-color:#48bb78; }
+.eq-idle { background:#3a4456; border-color:#718096; }
+.eq-badge { position:absolute; top:-6px; right:-6px; background:#f56565; color:#fff; border-radius:9px;
+    font-size:9px; font-weight:700; padding:0 5px; line-height:14px; min-width:14px; }
 
-.site-container {
-    background-color: #1a2238;
-    border-radius: 10px;
-    padding: 15px;
-    margin-bottom: 15px;
-    border: 2px solid #4a5568;
-}
-
-.site-header {
-    background-color: #0f1419;
-    padding: 10px 15px;
-    border-radius: 6px;
-    margin-bottom: 10px;
-    border-left: 3px solid var(--accent-color, #3182ce);
-}
-
-.location-container {
-    background-color: #2d3748;
-    border-radius: 8px;
-    padding: 12px;
-    margin-bottom: 10px;
-    border: 1px solid #4a5568;
-    position: relative;
-}
-
-.location-header {
-    font-weight: bold;
-    margin-bottom: 8px;
-    color: var(--info-color, #4299e1);
-}
-
-.equipment-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 10px;
-    margin-top: 10px;
-}
-
-.equipment-card {
-    background-color: var(--success-color, #48bb78);
-    color: white;
-    padding: 12px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    position: relative;
-}
-
-.equipment-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-}
-
-.equipment-card.status-active {
-    background-color: var(--success-color, #48bb78);
-    border: 2px solid #2f855a;
-}
-
-.equipment-card.status-inactive {
-    background-color: #718096;
-    border: 2px solid #4a5568;
-}
-
-.equipment-card.status-maintenance {
-    background-color: var(--warning-color, #ed8936);
-    border: 2px solid #c05621;
-}
-
-.equipment-card.status-retired {
-    background-color: #4a5568;
-    border: 2px solid #2d3748;
-}
-
-.equipment-card.status-cascade-offline {
-    background-color: var(--danger-color, #f56565);
-    border: 2px solid #c53030;
-    animation: pulse-red 2s infinite;
-}
-
-@keyframes pulse-red {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.7; }
-}
-
-.equipment-name {
-    font-weight: bold;
-    font-size: 13px;
-    margin-bottom: 4px;
-}
-
-.equipment-status {
-    font-size: 10px;
-    padding: 2px 6px;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 3px;
-    display: inline-block;
-}
-
-.equipment-connections {
-    font-size: 9px;
-    margin-top: 4px;
-    opacity: 0.8;
-}
-
-.connection-badge {
-    display: inline-block;
-    padding: 2px 6px;
-    border-radius: 3px;
-    margin-right: 4px;
-    background-color: rgba(0, 0, 0, 0.3);
-}
-
-.connection-badge.upstream {
-    color: #90cdf4;
-}
-
-.connection-badge.downstream {
-    color: #fc8181;
-}
-
-.legend {
-    background-color: #0f1419;
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 20px;
-}
-
-.legend-item {
-    display: inline-flex;
-    align-items: center;
-    margin-right: 20px;
-    margin-bottom: 8px;
-}
-
-.legend-color {
-    width: 20px;
-    height: 20px;
-    border-radius: 4px;
-    margin-right: 8px;
-}
-
-.map-controls {
-    background-color: #0f1419;
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 20px;
-}
-
-.map-controls .btn {
-    margin-right: 10px;
-    margin-bottom: 5px;
-}
-
-.customer-stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 10px;
-    margin-top: 10px;
-}
-
-.stat-box {
-    background-color: #2d3748;
-    padding: 10px;
-    border-radius: 6px;
-    text-align: center;
-    border: 1px solid #4a5568;
-}
-
-.stat-value {
-    font-size: 24px;
-    font-weight: bold;
-}
-
-.stat-label {
-    font-size: 11px;
-    opacity: 0.7;
-    text-transform: uppercase;
-}
-
-.empty-location {
-    color: #a0aec0;
-    font-style: italic;
-    padding: 10px;
-    text-align: center;
-}
+.map-empty { text-align:center; padding:60px 20px; color:#a0aec0; }
+.map-empty i { font-size:46px; color:#4a5568; margin-bottom:16px; }
+.unzoned-wrap { margin-top:18px; }
+.unzoned-grid { display:flex; flex-wrap:wrap; gap:8px; }
+.unzoned-grid .eq-box { position: static; width: 150px; height: 42px; }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="map-container">
-    <div class="map-header">
-        <div class="d-flex justify-content-between align-items-center">
-            <div>
-                <h2 class="mb-0">
-                    <i class="fas fa-project-diagram me-2"></i>
-                    Equipment Dependency Maps
-                </h2>
-                <p class="mb-0 text-light">Customer → Sites → Locations → Equipment hierarchy with dependencies</p>
-            </div>
-            <div>
-                <select class="form-select" onchange="filterByCustomer(this.value)" style="min-width: 200px;">
-                    <option value="all" {% if selected_customer_id == 'all' %}selected{% endif %}>All Customers</option>
-                    {% for customer in customers %}
-                    <option value="{{ customer.id }}" {% if selected_customer_id|stringformat:"s" == customer.id|stringformat:"s" %}selected{% endif %}>
-                        {{ customer.name }}
-                    </option>
-                    {% endfor %}
-                </select>
-            </div>
+<div class="map-header">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h3 class="mb-0 text-white"><i class="fas fa-map me-2"></i> Facility Map</h3>
+            <p class="text-muted mb-0">
+                {% if selected_site %}{{ selected_site.name }} — equipment by zone, color-coded by health{% else %}Select a site{% endif %}
+            </p>
         </div>
     </div>
-
-    <div class="legend">
-        <h5 class="mb-3"><i class="fas fa-info-circle me-2"></i>Legend</h5>
-        <div class="row">
-            <div class="col-md-8">
-                <strong>Equipment Status:</strong>
-                <div class="mt-2">
-                    <div class="legend-item">
-                        <div class="legend-color" style="background-color: var(--success-color, #48bb78);"></div>
-                        <span>Active</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background-color: var(--warning-color, #ed8936);"></div>
-                        <span>Under Maintenance</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background-color: #718096;"></div>
-                        <span>Inactive</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background-color: var(--danger-color, #f56565);"></div>
-                        <span>Cascade Offline (Upstream Failure)</span>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-4">
-                <strong>Connections:</strong>
-                <div class="mt-2">
-                    <div class="legend-item">
-                        <span class="connection-badge upstream">↑ Upstream</span>
-                        <span class="ms-1">Depends on</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="connection-badge downstream">↓ Downstream</span>
-                        <span class="ms-1">Supplies to</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div class="map-controls">
-        <strong><i class="fas fa-tools me-2"></i>Tools:</strong>
-        <button class="btn btn-sm btn-primary" onclick="showConnectionManager()">
-            <i class="fas fa-link"></i> Manage Connections
-        </button>
-        <button class="btn btn-sm btn-info" onclick="toggleConnectionInfo()">
-            <i class="fas fa-info-circle"></i> <span id="toggle-info-text">Show Connection Info</span>
-        </button>
-    </div>
-
-    {% if customer_maps %}
-        {% for customer_map in customer_maps %}
-        <div class="customer-map-section" id="customer-{{ customer_map.customer.id }}">
-            <div class="customer-map-header">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div>
-                        <h3 class="mb-1">
-                            <i class="fas fa-building me-2"></i>{{ customer_map.customer.name }}
-                        </h3>
-                        <p class="mb-0 text-muted small">
-                            {{ customer_map.equipment.count }} equipment across {{ customer_map.locations.count }} locations
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="customer-stats">
-                    <div class="stat-box">
-                        <div class="stat-value text-success">{{ customer_map.equipment.count }}</div>
-                        <div class="stat-label">Total Equipment</div>
-                    </div>
-                    <div class="stat-box">
-                        <div class="stat-value text-danger">
-                            {% with offline_count=0 %}
-                                {% for equip in customer_map.equipment %}
-                                    {% if equip.status == 'inactive' or equip.status == 'retired' %}
-                                        {{ offline_count|add:1 }}
-                                    {% endif %}
-                                {% endfor %}
-                                {{ offline_count }}
-                            {% endwith %}
-                        </div>
-                        <div class="stat-label">Offline</div>
-                    </div>
-                    <div class="stat-box">
-                        <div class="stat-value text-warning">
-                            {% with maint_count=0 %}
-                                {% for equip in customer_map.equipment %}
-                                    {% if equip.status == 'maintenance' %}
-                                        {{ maint_count|add:1 }}
-                                    {% endif %}
-                                {% endfor %}
-                                {{ maint_count }}
-                            {% endwith %}
-                        </div>
-                        <div class="stat-label">Maintenance</div>
-                    </div>
-                    <div class="stat-box">
-                        <div class="stat-value text-info">{{ customer_map.connections.count }}</div>
-                        <div class="stat-label">Connections</div>
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Sites and Locations -->
-            {% for site, sub_locations in customer_map.location_groups.items %}
-            <div class="site-container">
-                <div class="site-header">
-                    <h5 class="mb-0">
-                        {% if site %}
-                            <i class="fas fa-building me-2"></i>{{ site.name }}
-                        {% else %}
-                            <i class="fas fa-map-marker-alt me-2"></i>Independent Locations
-                        {% endif %}
-                    </h5>
-                </div>
-                
-                <!-- Sub-locations (Pods/MDCs) -->
-                {% for location in sub_locations %}
-                <div class="location-container">
-                    <div class="location-header">
-                        <i class="fas fa-map-marker-alt me-1"></i>{{ location.name }}
-                    </div>
-                    
-                    <div class="equipment-grid">
-                        {% for equip in customer_map.equipment %}
-                            {% if equip.location == location %}
-                            <div class="equipment-card status-{{ equip.status }}" 
-                                 data-equipment-id="{{ equip.id }}"
-                                 data-customer-id="{{ customer_map.customer.id }}"
-                                 onclick="showEquipmentDetail({{ equip.id }})">
-                                <div class="equipment-name">{{ equip.name }}</div>
-                                <div class="equipment-status">{{ equip.get_status_display }}</div>
-                                <div class="equipment-connections" id="equip-connections-{{ equip.id }}">
-                                    <!-- Connections populated by JS -->
-                                </div>
-                            </div>
-                            {% endif %}
-                        {% endfor %}
-                        
-                        {% with location_equipment=customer_map.equipment|length %}
-                            {% if location_equipment == 0 %}
-                            <div class="empty-location">
-                                <i class="fas fa-box-open me-1"></i>No equipment in this location
-                            </div>
-                            {% endif %}
-                        {% endwith %}
-                    </div>
-                </div>
-                {% empty %}
-                    <div class="empty-location">
-                        <i class="fas fa-map-marker-alt me-1"></i>No locations configured
-                    </div>
+        {% if sites %}
+        <form method="get" id="siteForm">
+            <label for="site_id" class="me-2">Site:</label>
+            <select name="site_id" id="site_id" class="map-select" onchange="document.getElementById('siteForm').submit()">
+                {% for s in sites %}
+                <option value="{{ s.id }}" {% if selected_site and s.id == selected_site.id %}selected{% endif %}>{{ s.name }}</option>
                 {% endfor %}
-            </div>
-            {% endfor %}
-            
-            <!-- Store data for this customer's map -->
-            <script>
-                if (!window.customerMapData) window.customerMapData = {};
-                window.customerMapData['{{ customer_map.customer.id }}'] = {
-                    connections: {{ customer_map.connections_json|safe }},
-                    equipment: {{ customer_map.equipment_json|safe }}
-                };
-            </script>
-        </div>
-        {% endfor %}
-    {% else %}
-        <div class="text-center py-5">
-            <i class="fas fa-building fa-3x mb-3 text-muted"></i>
-            <h4>No Customer Maps Available</h4>
-            <p class="text-muted">No customers with equipment have been configured yet.</p>
-            <div class="mt-3">
-                <a href="{% url 'core:customers_settings' %}" class="btn btn-primary me-2">
-                    <i class="fas fa-user-plus me-1"></i>Add Customers
-                </a>
-                <a href="{% url 'equipment:add_equipment' %}" class="btn btn-success">
-                    <i class="fas fa-cogs me-1"></i>Add Equipment
-                </a>
-            </div>
-        </div>
-    {% endif %}
-</div>
-
-<!-- Connection Manager Modal -->
-<div class="modal fade" id="connectionManagerModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content bg-dark text-light">
-            <div class="modal-header">
-                <h5 class="modal-title">
-                    <i class="fas fa-link me-2"></i>Manage Equipment Connections
-                </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <div class="alert alert-info">
-                    <i class="fas fa-info-circle me-2"></i>
-                    <strong>How it works:</strong> When upstream equipment goes offline, all downstream equipment with critical connections automatically cascade offline.
-                </div>
-                
-                <form id="connection-form">
-                    {% csrf_token %}
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group mb-3">
-                                <label for="upstream-equipment" class="form-label">
-                                    <i class="fas fa-arrow-up me-1"></i>Upstream Equipment (Supplies)
-                                </label>
-                                <select id="upstream-equipment" class="form-select" required>
-                                    <option value="">Select equipment...</option>
-                                    {% for equip in all_equipment %}
-                                    <option value="{{ equip.id }}">{{ equip.name }} ({{ equip.location.name }})</option>
-                                    {% endfor %}
-                                </select>
-                                <small class="text-muted">Equipment that provides power/data/service</small>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="form-group mb-3">
-                                <label for="downstream-equipment" class="form-label">
-                                    <i class="fas fa-arrow-down me-1"></i>Downstream Equipment (Depends)
-                                </label>
-                                <select id="downstream-equipment" class="form-select" required>
-                                    <option value="">Select equipment...</option>
-                                    {% for equip in all_equipment %}
-                                    <option value="{{ equip.id }}">{{ equip.name }} ({{ equip.location.name }})</option>
-                                    {% endfor %}
-                                </select>
-                                <small class="text-muted">Equipment that depends on the upstream</small>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group mb-3">
-                                <label for="connection-type" class="form-label">Connection Type</label>
-                                <select id="connection-type" class="form-select" required>
-                                    <option value="power">Power Supply</option>
-                                    <option value="data">Data Connection</option>
-                                    <option value="cooling">Cooling System</option>
-                                    <option value="control">Control System</option>
-                                    <option value="mechanical">Mechanical</option>
-                                    <option value="other">Other</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="form-group mb-3">
-                                <div class="form-check mt-4">
-                                    <input type="checkbox" class="form-check-input" id="is-critical" checked>
-                                    <label class="form-check-label" for="is-critical">
-                                        Critical Connection
-                                    </label>
-                                </div>
-                                <small class="d-block text-muted">If checked, downstream goes offline when upstream fails</small>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group mb-3">
-                        <label for="connection-description" class="form-label">Description (Optional)</label>
-                        <textarea id="connection-description" class="form-control" rows="2" placeholder="Describe this connection..."></textarea>
-                    </div>
-                </form>
-                
-                <hr>
-                
-                <h6><i class="fas fa-list me-2"></i>All Existing Connections</h6>
-                <div id="connections-list" style="max-height: 300px; overflow-y: auto;">
-                    <!-- Will be populated by JavaScript -->
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary" onclick="saveConnection()">
-                    <i class="fas fa-save"></i> Create Connection
-                </button>
-            </div>
+            </select>
+        </form>
+        {% endif %}
+        <div class="map-legend">
+            <span class="legend-item"><span class="legend-swatch lg-critical"></span> Critical / overdue</span>
+            <span class="legend-item"><span class="legend-swatch lg-warning"></span> Issue / due soon</span>
+            <span class="legend-item"><span class="legend-swatch lg-maintenance"></span> In maintenance</span>
+            <span class="legend-item"><span class="legend-swatch lg-ok"></span> OK</span>
+            <span class="legend-item"><span class="legend-swatch lg-idle"></span> Inactive</span>
         </div>
     </div>
 </div>
+
+{% if not sites %}
+    <div class="map-empty">
+        <i class="fas fa-map"></i>
+        <h5 class="text-muted">No sites defined</h5>
+        <p>Add a site under Settings → Locations to use the facility map.</p>
+    </div>
+{% else %}
+    <div id="canvasWrap">
+        <div id="facilityCanvas"></div>
+    </div>
+    <div id="mapEmpty" class="map-empty" style="display:none;">
+        <i class="fas fa-vector-square"></i>
+        <h5 class="text-muted">No equipment to map for this site</h5>
+        <p>Once this site has zones and equipment, they'll appear here. (Drag-to-arrange editor coming soon.)</p>
+    </div>
+    <div id="unzonedWrap" class="unzoned-wrap" style="display:none;">
+        <h6 class="text-muted"><i class="fas fa-layer-group me-1"></i> Not assigned to a zone</h6>
+        <div id="unzonedGrid" class="unzoned-grid"></div>
+    </div>
+{% endif %}
 {% endblock %}
 
 {% block extra_js %}
 <script>
-// Global state
-let showConnectionInfo = false;
+(function () {
+    var layout = {{ site_layout_json|safe }};
+    if (!layout) { return; }
 
-// Initialize on page load
-document.addEventListener('DOMContentLoaded', function() {
-    updateAllEquipmentConnections();
-    updateAllEquipmentStatus();
-    loadExistingConnections();
-});
+    var canvas = document.getElementById('facilityCanvas');
+    var wrap = document.getElementById('canvasWrap');
+    var empty = document.getElementById('mapEmpty');
 
-function updateAllEquipmentStatus() {
-    if (!window.customerMapData) return;
-    
-    Object.keys(window.customerMapData).forEach(customerId => {
-        const data = window.customerMapData[customerId];
-        
-        data.equipment.forEach(equip => {
-            const card = document.querySelector(`[data-equipment-id="${equip.id}"][data-customer-id="${customerId}"]`);
-            if (card) {
-                // Remove all status classes
-                card.classList.remove('status-active', 'status-inactive', 'status-maintenance', 'status-retired', 'status-cascade-offline');
-                
-                // Add appropriate status class
-                if (equip.is_cascade_offline) {
-                    card.classList.add('status-cascade-offline');
-                } else {
-                    card.classList.add('status-' + equip.status);
-                }
-            }
-        });
-    });
-}
+    function eqHref(id) { return '/equipment/' + id + '/'; }
 
-function updateAllEquipmentConnections() {
-    if (!window.customerMapData) return;
-    
-    Object.keys(window.customerMapData).forEach(customerId => {
-        const data = window.customerMapData[customerId];
-        
-        data.equipment.forEach(equip => {
-            const connectionsEl = document.getElementById(`equip-connections-${equip.id}`);
-            if (!connectionsEl) return;
-            
-            // Count upstream and downstream connections
-            const upstreamCount = data.connections.filter(c => c.downstream_id === equip.id).length;
-            const downstreamCount = data.connections.filter(c => c.upstream_id === equip.id).length;
-            
-            let html = '';
-            if (upstreamCount > 0) {
-                html += `<span class="connection-badge upstream" title="${upstreamCount} upstream connection(s)">↑${upstreamCount}</span>`;
-            }
-            if (downstreamCount > 0) {
-                html += `<span class="connection-badge downstream" title="${downstreamCount} downstream connection(s)">↓${downstreamCount}</span>`;
-            }
-            
-            connectionsEl.innerHTML = html;
-            connectionsEl.style.display = (upstreamCount > 0 || downstreamCount > 0) ? 'block' : 'none';
-        });
-    });
-}
-
-function toggleConnectionInfo() {
-    showConnectionInfo = !showConnectionInfo;
-    const allConnections = document.querySelectorAll('.equipment-connections');
-    allConnections.forEach(el => {
-        if (showConnectionInfo) {
-            el.style.display = 'block';
-        } else {
-            // Only hide if no connections
-            if (el.innerHTML.trim() === '') {
-                el.style.display = 'none';
-            }
+    function makeEqBox(eq, absolute) {
+        var box = document.createElement('div');
+        box.className = 'eq-box eq-' + eq.health;
+        box.title = eq.tooltip;
+        if (absolute && eq.x !== null && eq.x !== undefined) {
+            box.style.left = eq.x + 'px'; box.style.top = eq.y + 'px';
+            box.style.width = (eq.w || 90) + 'px'; box.style.height = (eq.h || 40) + 'px';
         }
-    });
-    document.getElementById('toggle-info-text').textContent = 
-        showConnectionInfo ? 'Hide Connection Info' : 'Show Connection Info';
-}
-
-function showEquipmentDetail(equipId) {
-    window.open(`/equipment/${equipId}/`, '_blank');
-}
-
-function filterByCustomer(customerId) {
-    const currentUrl = new URL(window.location.href);
-    if (customerId === 'all') {
-        currentUrl.searchParams.delete('customer_id');
-    } else {
-        currentUrl.searchParams.set('customer_id', customerId);
+        var name = document.createElement('span');
+        name.className = 'eq-name';
+        name.textContent = eq.name;
+        box.appendChild(name);
+        if (eq.open_issues > 0) {
+            var b = document.createElement('span');
+            b.className = 'eq-badge';
+            b.textContent = eq.open_issues;
+            box.appendChild(b);
+        }
+        box.addEventListener('click', function () { window.location.href = eqHref(eq.id); });
+        return box;
     }
-    window.location.href = currentUrl.toString();
-}
 
-function showConnectionManager() {
-    loadExistingConnections();
-    const modal = new bootstrap.Modal(document.getElementById('connectionManagerModal'));
-    modal.show();
-}
-
-function loadExistingConnections() {
-    const listEl = document.getElementById('connections-list');
-    if (!window.customerMapData) {
-        listEl.innerHTML = '<p class="text-muted">No connections defined yet.</p>';
+    var hasContent = (layout.pods && layout.pods.length) || (layout.unzoned && layout.unzoned.length);
+    if (!hasContent) {
+        wrap.style.display = 'none';
+        if (empty) empty.style.display = 'block';
         return;
     }
-    
-    // Collect all connections from all customers
-    let allConnections = [];
-    Object.keys(window.customerMapData).forEach(customerId => {
-        const data = window.customerMapData[customerId];
-        data.connections.forEach(conn => {
-            const upstream = data.equipment.find(e => e.id === conn.upstream_id);
-            const downstream = data.equipment.find(e => e.id === conn.downstream_id);
-            if (upstream && downstream) {
-                allConnections.push({
-                    ...conn,
-                    upstream_name: upstream.name,
-                    downstream_name: downstream.name,
-                    upstream_location: upstream.location_name,
-                    downstream_location: downstream.location_name,
-                    customerId: customerId
-                });
-            }
-        });
-    });
-    
-    if (allConnections.length === 0) {
-        listEl.innerHTML = '<p class="text-muted">No connections defined yet. Create connections to show equipment dependencies.</p>';
-        return;
-    }
-    
-    // Sort by upstream name
-    allConnections.sort((a, b) => a.upstream_name.localeCompare(b.upstream_name));
-    
-    let html = '<div class="list-group">';
-    allConnections.forEach(conn => {
-        const criticalBadge = conn.is_critical 
-            ? '<span class="badge bg-danger">Critical</span>' 
-            : '<span class="badge bg-info">Non-Critical</span>';
-        
-        html += `
-            <div class="list-group-item bg-secondary text-light mb-2">
-                <div class="d-flex justify-content-between align-items-start">
-                    <div class="flex-grow-1">
-                        <div class="mb-1">
-                            <strong>${conn.upstream_name}</strong> <small class="text-muted">(${conn.upstream_location})</small>
-                            <br>
-                            <i class="fas fa-arrow-down text-warning mx-2"></i>
-                            <br>
-                            <strong>${conn.downstream_name}</strong> <small class="text-muted">(${conn.downstream_location})</small>
-                        </div>
-                        <small class="text-muted">
-                            <span class="badge bg-primary">${conn.connection_type}</span>
-                            ${criticalBadge}
-                        </small>
-                    </div>
-                    <button class="btn btn-sm btn-danger" onclick="deleteConnection(${conn.id}, '${conn.customerId}')">
-                        <i class="fas fa-trash"></i>
-                    </button>
-                </div>
-            </div>
-        `;
-    });
-    html += '</div>';
-    listEl.innerHTML = html;
-}
 
-function saveConnection() {
-    const upstreamId = document.getElementById('upstream-equipment').value;
-    const downstreamId = document.getElementById('downstream-equipment').value;
-    const connectionType = document.getElementById('connection-type').value;
-    const isCritical = document.getElementById('is-critical').checked;
-    const description = document.getElementById('connection-description').value;
-    
-    if (!upstreamId || !downstreamId) {
-        alert('Please select both upstream and downstream equipment.');
-        return;
-    }
-    
-    if (upstreamId === downstreamId) {
-        alert('Equipment cannot connect to itself.');
-        return;
-    }
-    
-    // Create connection via API
-    fetch('/equipment/api/connections/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': '{{ csrf_token }}'
-        },
-        body: JSON.stringify({
-            upstream_equipment: upstreamId,
-            downstream_equipment: downstreamId,
-            connection_type: connectionType,
-            is_critical: isCritical,
-            description: description
-        })
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.status === 'success') {
-            // Show success and reload
-            if (window.showMessage) {
-                window.showMessage('Connection created successfully! Reloading map...', 'success');
-            }
-            setTimeout(() => window.location.reload(), 1000);
-        } else {
-            alert('Error creating connection: ' + (data.message || 'Unknown error'));
-        }
-    })
-    .catch(error => {
-        console.error('Error:', error);
-        alert('Error creating connection. Check console for details.');
-    });
-}
+    canvas.style.width = layout.site.width + 'px';
+    canvas.style.height = layout.site.height + 'px';
 
-function deleteConnection(connectionId, customerId) {
-    if (!confirm('Are you sure you want to delete this connection?')) return;
-    
-    fetch(`/equipment/api/connections/${connectionId}/`, {
-        method: 'DELETE',
-        headers: {
-            'X-CSRFToken': '{{ csrf_token }}'
-        }
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.status === 'success') {
-            // Show success and reload
-            if (window.showMessage) {
-                window.showMessage('Connection deleted successfully! Reloading map...', 'success');
-            }
-            setTimeout(() => window.location.reload(), 1000);
-        } else {
-            alert('Error deleting connection: ' + (data.message || 'Unknown error'));
-        }
-    })
-    .catch(error => {
-        console.error('Error:', error);
-        alert('Error deleting connection. Check console for details.');
+    (layout.pods || []).forEach(function (pod) {
+        var zone = document.createElement('div');
+        zone.className = 'pod-zone';
+        zone.style.left = pod.x + 'px'; zone.style.top = pod.y + 'px';
+        zone.style.width = pod.w + 'px'; zone.style.height = pod.h + 'px';
+
+        var header = document.createElement('div');
+        header.className = 'pod-header';
+        var counts = '';
+        if (pod.counts.critical) counts += '<span style="color:#f56565">●</span>' + pod.counts.critical + ' ';
+        if (pod.counts.warning) counts += '<span style="color:#ed8936">●</span>' + pod.counts.warning + ' ';
+        header.innerHTML = '<span class="pod-counts">' + counts + '</span>' + pod.name;
+        zone.appendChild(header);
+
+        (pod.equipment || []).forEach(function (eq) { zone.appendChild(makeEqBox(eq, true)); });
+        canvas.appendChild(zone);
     });
-}
+
+    if (layout.unzoned && layout.unzoned.length) {
+        var uw = document.getElementById('unzonedWrap');
+        var ug = document.getElementById('unzonedGrid');
+        uw.style.display = 'block';
+        layout.unzoned.forEach(function (eq) { ug.appendChild(makeEqBox(eq, false)); });
+    }
+
+    function fit() {
+        var scale = Math.min(1, wrap.clientWidth / layout.site.width);
+        canvas.style.transform = 'scale(' + scale + ')';
+        wrap.style.height = (layout.site.height * scale) + 'px';
+    }
+    fit();
+    window.addEventListener('resize', fit);
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
Phase 2 of the facility-map overhaul. Replaces the old customer/connection-topology map with a **per-site facility floor plan**.

## What renders
- **Site picker** (honors the global site selector / `?site_id`).
- **POD/container zones** on a blank-grid canvas, each with a header showing critical/warning counts.
- **Equipment boxes** inside their zone, **color-coded by health**:
  - 🔴 critical — open *critical* issue or overdue maintenance
  - 🟠 warning — any open issue or maintenance due within 14 days
  - 🔵 in maintenance · 🟢 ok · ⚪ inactive/retired
  - issue-count badge; click → equipment detail.
- **Legend**, empty states, and an "unzoned equipment" strip.
- Canvas scales to fit width.

## How positions are determined
Uses saved `layout_*` coordinates when present; otherwise computes an **auto-grid** (PODs across the canvas, equipment within each zone) so the map is immediately useful before anything is hand-placed. The Phase 3 drag editor will persist manual positions into those same fields.

Connection topology is set aside for now (can return later as an optional overlay).

## Verify (dev)
Map nav → pick a site → zones + equipment appear, colored by health; click a box → equipment detail. Sites with no equipment show an empty state.

Phase 3 next: drag-and-drop layout editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)