### PR TITLE
feat(locations): Generate PDUs button on Locations settings (SSDEV-26 #2)

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
     path('debug/populate-demo/', views.populate_demo_data, name='populate_demo_data'),
     path('debug/generate-pods/', views.generate_pods, name='generate_pods'),
     path('debug/generate-mdcs/', views.generate_mdcs, name='generate_mdcs'),
+    path('debug/generate-pdus/', views.generate_pdus, name='generate_pdus'),
     path('docker/containers/', views.get_docker_containers_api, name='get_docker_containers'),
     path('docker/logs/', views.get_docker_logs_api, name='get_docker_logs'),
     path('docker/aggregated-logs/', views.get_aggregated_logs_api, name='get_aggregated_logs'),

--- a/core/views/debug_data.py
+++ b/core/views/debug_data.py
@@ -106,6 +106,52 @@ def clear_maintenance_data(request):
 @login_required
 @user_passes_test(is_staff_or_superuser)
 @require_http_methods(["POST"])
+def generate_pdus(request):
+    """Generate PDU equipment ("PDU {building}-{n}") under an MDC location.
+    Wraps the create_pdus management command (always --apply from the UI)."""
+    try:
+        location_id = request.POST.get('location_id', '').strip()
+        building_map = request.POST.get('map', '').strip()
+        building = request.POST.get('building', '').strip()
+        count = request.POST.get('count', '').strip()
+
+        if not location_id:
+            return JsonResponse({'success': False, 'error': 'Select a target MDC location.'}, status=400)
+        if not building_map and not (building and count):
+            return JsonResponse({'success': False, 'error': 'Provide a building:count map, or a building and count.'}, status=400)
+
+        args = ['create_pdus', '--location-id', location_id, '--apply']
+        if building_map:
+            args += ['--map', building_map]
+        else:
+            args += ['--building', building, '--count', count]
+
+        output = StringIO()
+        call_command(*args, stdout=output, stderr=output, verbosity=2)
+        result = output.getvalue()
+        output.close()
+
+        m = re.search(r'Created (\d+)', result)
+        created_count = int(m.group(1)) if m else 0
+
+        return JsonResponse({
+            'success': True,
+            'message': f'PDU generation complete! Created: {created_count} PDU(s).',
+            'created_count': created_count,
+            'output': result,
+        })
+    except Exception as e:
+        import traceback
+        return JsonResponse({
+            'success': False,
+            'error': f'Error generating PDUs: {str(e)}',
+            'details': traceback.format_exc(),
+        }, status=500)
+
+
+@login_required
+@user_passes_test(is_staff_or_superuser)
+@require_http_methods(["POST"])
 def generate_pods(request):
     """Generate PODs for selected sites or all sites."""
     try:
@@ -528,4 +574,4 @@ def clear_database(request):
         }, status=500)
 
 
-__all__ = ["clear_maintenance_data", "generate_pods", "generate_mdcs", "populate_demo_data", "clear_maintenance_activities", "clear_database"]
+__all__ = ["clear_maintenance_data", "generate_pods", "generate_mdcs", "generate_pdus", "populate_demo_data", "clear_maintenance_activities", "clear_database"]

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -290,11 +290,19 @@ def locations_settings(request):
             child.child_locations_sorted = sorted(child.child_locations.all(), key=lambda loc: natural_sort_key(loc.name))
     
     customers = Customer.objects.filter(is_active=True).order_by('name')
-    
+
+    # MDC-level locations (children of PODs) — targets for the Generate PDUs modal.
+    mdc_locations = sorted(
+        Location.objects.filter(is_site=False, parent_location__is_site=False, is_active=True)
+            .select_related('parent_location', 'parent_location__parent_location'),
+        key=lambda l: natural_sort_key(l.get_hierarchical_display()),
+    )
+
     context = {
         'locations': locations,
         'sites': sites,
         'customers': customers,
+        'mdc_locations': mdc_locations,
     }
     return render(request, 'core/locations_settings.html', context)
 

--- a/templates/core/locations_settings.html
+++ b/templates/core/locations_settings.html
@@ -313,6 +313,10 @@
                 <i class="fas fa-magic me-1"></i>
                 Generate MDCs
             </button>
+            <button class="btn btn-outline-success me-2" data-toggle="modal" data-target="#generatePdusModal">
+                <i class="fas fa-magic me-1"></i>
+                Generate PDUs
+            </button>
             <button class="btn btn-outline-info" data-toggle="modal" data-target="#addCustomerModal">
                 <i class="fas fa-user-plus me-1"></i>
                 Add Customer
@@ -846,6 +850,63 @@
         </div>
     </div>
 </div>
+
+<!-- Generate PDUs Modal -->
+<div class="modal fade" id="generatePdusModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fas fa-bolt me-2"></i> Generate PDUs</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <form id="generatePdusForm">
+                <div class="modal-body">
+                    <div class="alert alert-info">
+                        Creates PDU equipment named <code>PDU {building}-{n}</code> (e.g. <code>PDU 10-1</code>)
+                        under the selected MDC location. Re-running is safe — existing PDUs are skipped.
+                    </div>
+                    <div class="mb-3">
+                        <label for="pduLocationSelect" class="form-label">Target MDC <span class="text-danger">*</span></label>
+                        <select id="pduLocationSelect" name="location_id" class="form-control" required>
+                            <option value="">Select an MDC…</option>
+                            {% for mdc in mdc_locations %}
+                            <option value="{{ mdc.id }}">{{ mdc.get_hierarchical_display }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="pduMap" class="form-label">Buildings &amp; counts</label>
+                        <input type="text" id="pduMap" name="map" class="form-control" placeholder="e.g. 10:6, 11:6">
+                        <small class="form-text text-muted">
+                            Comma-separated <code>building:count</code> pairs. <code>10:6</code> = building 10, PDUs 1–6.
+                            Or use the single-building fields below.
+                        </small>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="pduBuilding" class="form-label">Building #</label>
+                            <input type="number" id="pduBuilding" name="building" class="form-control" min="1">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="pduCount" class="form-label">PDUs in building</label>
+                            <input type="number" id="pduCount" name="count" class="form-control" min="1">
+                        </div>
+                    </div>
+                    <div id="generatePdusOutput" class="mt-3" style="display: none;">
+                        <label class="form-label">Output</label>
+                        <pre id="generatePdusOutputText" class="bg-dark text-light p-3 rounded" style="max-height: 200px; overflow-y: auto; font-size: 12px;"></pre>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-success" id="generatePdusBtn">
+                        <i class="fas fa-magic me-1"></i> Generate PDUs
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -1312,6 +1373,54 @@ $(document).ready(function() {
         });
     });
     
+    // Generate PDUs Form
+    $('#generatePdusForm').on('submit', function(e) {
+        e.preventDefault();
+
+        const $submitBtn = $('#generatePdusBtn');
+        const originalText = $submitBtn.html();
+        const $output = $('#generatePdusOutput');
+        const $outputText = $('#generatePdusOutputText');
+
+        $submitBtn.prop('disabled', true).html('<i class="fas fa-spinner fa-spin me-1"></i> Generating...');
+        $output.hide();
+
+        const formData = new FormData(this);
+
+        $.ajax({
+            url: '{% url "core:generate_pdus" %}',
+            method: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function(response) {
+                if (response.success) {
+                    $outputText.text(response.output || 'PDUs generated successfully!');
+                    $output.show();
+                    $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
+                      response.message +
+                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '</div>').prependTo('.locations-header').delay(5000).fadeOut();
+                    setTimeout(function() { location.reload(); }, 2000);
+                } else {
+                    alert('Error: ' + (response.error || 'Unknown error occurred'));
+                }
+            },
+            error: function(xhr) {
+                let errorMessage = 'Error generating PDUs';
+                if (xhr.responseJSON) {
+                    errorMessage += ': ' + (xhr.responseJSON.error || xhr.responseJSON.message || 'Unknown error');
+                } else if (xhr.responseText) {
+                    errorMessage += ': ' + xhr.responseText;
+                }
+                alert(errorMessage);
+            },
+            complete: function() {
+                $submitBtn.prop('disabled', false).html(originalText);
+            }
+        });
+    });
+
     // Load PODs when site is selected in Generate MDCs modal
     $('#generateMdcsSiteSelect').on('change', function() {
         const siteId = $(this).val();


### PR DESCRIPTION
Unifies PDU creation with the existing **Generate PODs / Generate MDCs** tools on `/locations/settings/` — no CLI needed.

## What's new
- **Generate PDUs** button + modal next to the POD/MDC ones.
  - Pick a **target MDC** (dropdown of MDC-level locations, shown by full path).
  - Enter a **building:count map** (e.g. `10:6, 11:6`) or a single **building + count**.
  - Creates `PDU {building}-{n}` equipment under that MDC, ensures a `PDU` category. Re-running skips existing PDUs.
- `core:generate_pdus` AJAX view wraps the `create_pdus` command (`--apply`), mirroring the POD/MDC handlers (output panel + page reload).

Builds on #129 (the `create_pdus` command stays available for scripting).

## Verify (dev)
Locations settings → **Generate PDUs** → pick an MDC, enter `10:6` → Generate → 6 PDUs (`PDU 10-1`…`PDU 10-6`) appear under that MDC; re-run skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)