### PR TITLE
fix(locations): Generate PDUs 403 (missing CSRF token)

### DIFF
--- a/templates/core/locations_settings.html
+++ b/templates/core/locations_settings.html
@@ -860,6 +860,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <form id="generatePdusForm">
+                {% csrf_token %}
                 <div class="modal-body">
                     <div class="alert alert-info">
                         Creates PDU equipment named <code>PDU {building}-{n}</code> (e.g. <code>PDU 10-1</code>)


### PR DESCRIPTION
The Generate PDUs modal form was missing `{% csrf_token %}`, so its FormData POST carried no `csrfmiddlewaretoken` → Django returned **403 CSRF verification failed**. Added the token (the PODs/MDCs forms already have it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)