### PR TITLE
feat(locations): clearer Generate PDUs (MDC=building, per-site, idempotent)

### DIFF
--- a/core/views/debug_data.py
+++ b/core/views/debug_data.py
@@ -110,21 +110,20 @@ def generate_pdus(request):
     """Generate PDU equipment ("PDU {building}-{n}") under an MDC location.
     Wraps the create_pdus management command (always --apply from the UI)."""
     try:
+        site_id = request.POST.get('site_id', '').strip()
         location_id = request.POST.get('location_id', '').strip()
-        building_map = request.POST.get('map', '').strip()
-        building = request.POST.get('building', '').strip()
         count = request.POST.get('count', '').strip()
 
-        if not location_id:
-            return JsonResponse({'success': False, 'error': 'Select a target MDC location.'}, status=400)
-        if not building_map and not (building and count):
-            return JsonResponse({'success': False, 'error': 'Provide a building:count map, or a building and count.'}, status=400)
+        if not count:
+            return JsonResponse({'success': False, 'error': 'Enter how many PDUs per MDC.'}, status=400)
+        if not site_id and not location_id:
+            return JsonResponse({'success': False, 'error': 'Select a site (or a single MDC).'}, status=400)
 
-        args = ['create_pdus', '--location-id', location_id, '--apply']
-        if building_map:
-            args += ['--map', building_map]
+        args = ['create_pdus', '--count', count, '--apply']
+        if location_id:
+            args += ['--location-id', location_id]   # single MDC overrides site
         else:
-            args += ['--building', building, '--count', count]
+            args += ['--site-id', site_id]
 
         output = StringIO()
         call_command(*args, stdout=output, stderr=output, verbosity=2)

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -297,6 +297,9 @@ def locations_settings(request):
             .select_related('parent_location', 'parent_location__parent_location'),
         key=lambda l: natural_sort_key(l.get_hierarchical_display()),
     )
+    for mdc in mdc_locations:
+        site_loc = mdc.get_site_location()
+        mdc.site_id = site_loc.id if site_loc else ''
 
     context = {
         'locations': locations,

--- a/equipment/management/commands/create_pdus.py
+++ b/equipment/management/commands/create_pdus.py
@@ -1,137 +1,127 @@
 """
-Create PDU equipment under an MDC location, following the naming schema
-"PDU {building}-{n}" (e.g. PDU 10-1 = building 10, PDU 1) — SSDEV-26 #2.
+Create PDU equipment under MDC locations, named "PDU {building}-{n}"
+(e.g. PDU 10-1 = building 10, PDU 1) — SSDEV-26 #2.
 
-Idempotent (skips PDUs that already exist by name) and dry-run by default.
+An MDC *is* a building: the building number is taken from the MDC's name
+(the integer in "MDC 10"). You choose a whole site (every MDC under it) or a
+single MDC, and how many PDUs per MDC.
+
+Idempotent: PDUs that already exist (by name) are skipped — re-running never
+duplicates or recreates them. Dry-run by default; pass --apply to write.
 
 Examples:
-  # building 10, PDUs 1..6 under the MDC location named "MDC 1" (dry-run)
-  python manage.py create_pdus --map "10:6" --location-name "MDC 1"
-
-  # multiple buildings, then actually write
-  python manage.py create_pdus --map "10:6,11:6" --location-name "MDC 1" --apply
-
-  # target an exact location id (skips name lookup)
-  python manage.py create_pdus --building 10 --count 6 --location-id 42 --apply
+  # every MDC under a site, 36 PDUs each (preview)
+  python manage.py create_pdus --site-id 3 --count 36
+  # just one MDC, 36 PDUs, write for real
+  python manage.py create_pdus --location-id 42 --count 36 --apply
 """
 
+import re
+
 from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User
 
 from core.models import EquipmentCategory, Location
+from core.utils import get_all_descendant_location_ids
 from equipment.models import Equipment
 
 
 class Command(BaseCommand):
-    help = ('Create PDU equipment ("PDU {building}-{n}") under an MDC location. '
-            'Dry-run unless --apply.')
+    help = ('Create "PDU {building}-{n}" equipment under MDC locations '
+            '(building number derived from the MDC name). Dry-run unless --apply.')
 
     def add_arguments(self, parser):
-        parser.add_argument('--map', dest='map',
-                            help='Comma-separated building:count pairs, e.g. "10:6,11:6".')
-        parser.add_argument('--building', type=int, help='Single building number (with --count).')
-        parser.add_argument('--count', type=int, help='PDUs per building (1..count), with --building.')
-        parser.add_argument('--location-id', type=int, help='Target location id (the MDC).')
-        parser.add_argument('--location-name', help='Target location name, e.g. "MDC 1".')
-        parser.add_argument('--site', help='Site name to disambiguate --location-name.')
+        parser.add_argument('--site-id', type=int, help='Generate for every MDC under this site.')
+        parser.add_argument('--site', help='Site name (alternative to --site-id).')
+        parser.add_argument('--location-id', type=int, help='Generate for a single MDC location id.')
+        parser.add_argument('--count', type=int, required=True, help='PDUs per MDC/building (1..count).')
+        parser.add_argument('--building', type=int,
+                            help='Override the building number (only valid with a single --location-id).')
         parser.add_argument('--category', default='PDU', help='Equipment category name (default: PDU).')
         parser.add_argument('--apply', action='store_true', help='Persist changes (otherwise report only).')
 
-    # ----- helpers -----
-    def _parse_buildings(self, options):
-        """Return an ordered list of (building, count) from --map or --building/--count."""
-        pairs = []
-        if options.get('map'):
-            for chunk in options['map'].split(','):
-                chunk = chunk.strip()
-                if not chunk:
-                    continue
-                try:
-                    b, c = chunk.split(':')
-                    pairs.append((int(b), int(c)))
-                except ValueError:
-                    raise CommandError(f'Bad --map entry "{chunk}"; expected building:count.')
-        if options.get('building') is not None:
-            if options.get('count') is None:
-                raise CommandError('--building requires --count.')
-            pairs.append((options['building'], options['count']))
-        if not pairs:
-            raise CommandError('Provide --map "10:6,11:6" or --building N --count M.')
-        for _, c in pairs:
-            if c < 1:
-                raise CommandError('count must be >= 1.')
-        return pairs
-
-    def _resolve_location(self, options):
+    def _resolve_mdcs(self, options):
+        """Return the list of target MDC locations."""
         if options.get('location_id'):
             try:
-                return Location.objects.get(id=options['location_id'])
+                return [Location.objects.get(id=options['location_id'])]
             except Location.DoesNotExist:
                 raise CommandError(f"No location with id {options['location_id']}.")
-        name = options.get('location_name')
-        if not name:
-            raise CommandError('Provide --location-id or --location-name (the MDC).')
-        qs = Location.objects.filter(name=name)
-        matches = list(qs)
-        if options.get('site'):
-            matches = [m for m in matches if (m.get_site_location() and m.get_site_location().name == options['site'])]
-        if not matches:
-            raise CommandError(f'No location named "{name}"' + (f' under site "{options["site"]}".' if options.get('site') else '.'))
-        if len(matches) > 1:
-            paths = "\n  ".join(f'id={m.id}: {m.get_hierarchical_display()}' for m in matches)
-            raise CommandError(f'Multiple locations named "{name}". Use --site or --location-id:\n  {paths}')
-        return matches[0]
 
-    # ----- main -----
+        site = None
+        if options.get('site_id'):
+            try:
+                site = Location.objects.get(id=options['site_id'], is_site=True)
+            except Location.DoesNotExist:
+                raise CommandError(f"No site with id {options['site_id']}.")
+        elif options.get('site'):
+            matches = list(Location.objects.filter(name=options['site'], is_site=True))
+            if not matches:
+                raise CommandError(f'No site named "{options["site"]}".')
+            if len(matches) > 1:
+                raise CommandError(f'Multiple sites named "{options["site"]}"; use --site-id.')
+            site = matches[0]
+        else:
+            raise CommandError('Provide --site-id / --site (whole site) or --location-id (single MDC).')
+
+        # MDCs = locations under the site whose parent is a POD (i.e. not the site itself).
+        descendant_ids = get_all_descendant_location_ids(site, include_inactive=True)
+        mdcs = list(Location.objects.filter(
+            id__in=descendant_ids, is_site=False, parent_location__is_site=False, is_active=True))
+        if not mdcs:
+            raise CommandError(f'No MDC-level locations found under site "{site.name}".')
+        return mdcs
+
+    def _building_for(self, mdc, override, single):
+        if override is not None and single:
+            return override
+        m = re.search(r'\d+', mdc.name or '')
+        return int(m.group()) if m else None
+
     def handle(self, *args, **options):
         apply_changes = options['apply']
-        buildings = self._parse_buildings(options)
-        location = self._resolve_location(options)
-        system_user = User.objects.filter(is_superuser=True).order_by('id').first()
+        count = options['count']
+        if count < 1:
+            raise CommandError('--count must be >= 1.')
+
+        mdcs = self._resolve_mdcs(options)
+        single = bool(options.get('location_id'))
+        if options.get('building') is not None and not single:
+            raise CommandError('--building is only valid with a single --location-id.')
 
         mode = 'APPLY' if apply_changes else 'DRY-RUN'
-        self.stdout.write(f"Create PDUs [{mode}]")
-        self.stdout.write(f"  Location : {location.get_hierarchical_display()} (id={location.id})")
-        self.stdout.write(f"  Category : {options['category']}")
+        self.stdout.write(f"Create PDUs [{mode}] — {len(mdcs)} MDC(s), {count} per MDC, category '{options['category']}'")
 
         category = None
         if apply_changes:
-            category, cat_created = EquipmentCategory.objects.get_or_create(
+            category, _ = EquipmentCategory.objects.get_or_create(
                 name=options['category'], defaults={'is_active': True})
-            if cat_created:
-                self.stdout.write(self.style.SUCCESS(f"  + created category '{options['category']}'"))
-        else:
-            existing_cat = EquipmentCategory.objects.filter(name=options['category']).first()
-            if not existing_cat:
-                self.stdout.write(f"  (would create category '{options['category']}')")
 
         created = skipped = 0
-        for building, count in buildings:
+        for mdc in sorted(mdcs, key=lambda m: m.name):
+            building = self._building_for(mdc, options.get('building'), single)
+            if building is None:
+                self.stdout.write(self.style.WARNING(
+                    f"  ! skipping {mdc.get_hierarchical_display()} — no building number in name"))
+                continue
+            self.stdout.write(f"  {mdc.get_hierarchical_display()} -> building {building}")
             for i in range(1, count + 1):
                 name = f"PDU {building}-{i}"
                 tag = f"PDU-{building}-{i}"
                 if Equipment.objects.filter(name=name).exists():
-                    self.stdout.write(f"  = exists: {name}")
                     skipped += 1
                     continue
-                self.stdout.write(self.style.SUCCESS(f"  + {name}  (asset_tag={tag})"))
                 created += 1
+                self.stdout.write(self.style.SUCCESS(f"    + {name}"))
                 if apply_changes:
                     Equipment.objects.create(
-                        name=name,
-                        category=category,
-                        location=location,
-                        manufacturer_serial=tag,
-                        asset_tag=tag,
-                        status='active',
-                        is_active=True,
-                        created_by=system_user,
-                        updated_by=system_user,
+                        name=name, category=category, location=mdc,
+                        manufacturer_serial=tag, asset_tag=tag,
+                        status='active', is_active=True,
                     )
 
-        summary = f"{created} PDU(s) to create, {skipped} already present."
+        summary = f"{created} PDU(s) to create, {skipped} already present (skipped)."
         if apply_changes:
-            summary = f"Created {created} PDU(s); {skipped} already present."
+            summary = f"Created {created} PDU(s); {skipped} already present (skipped)."
         elif created:
             summary += " Re-run with --apply to persist."
         self.stdout.write(self.style.SUCCESS(summary))

--- a/templates/core/locations_settings.html
+++ b/templates/core/locations_settings.html
@@ -863,35 +863,33 @@
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="alert alert-info">
-                        Creates PDU equipment named <code>PDU {building}-{n}</code> (e.g. <code>PDU 10-1</code>)
-                        under the selected MDC location. Re-running is safe — existing PDUs are skipped.
+                        Creates PDUs for each <strong>MDC (building)</strong> — named <code>PDU {building}-{n}</code>,
+                        where the building number comes from the MDC's name (e.g. <em>MDC 10</em> → <code>PDU 10-1</code>, <code>PDU 10-2</code>…).
+                        <br>Existing PDUs are <strong>skipped</strong>, so re-running never duplicates or recreates them.
                     </div>
                     <div class="mb-3">
-                        <label for="pduLocationSelect" class="form-label">Target MDC <span class="text-danger">*</span></label>
-                        <select id="pduLocationSelect" name="location_id" class="form-control" required>
-                            <option value="">Select an MDC…</option>
-                            {% for mdc in mdc_locations %}
-                            <option value="{{ mdc.id }}">{{ mdc.get_hierarchical_display }}</option>
+                        <label for="pduSiteSelect" class="form-label">Site <span class="text-danger">*</span></label>
+                        <select id="pduSiteSelect" name="site_id" class="form-control" required>
+                            <option value="">Select a site…</option>
+                            {% for site in sites %}
+                            <option value="{{ site.id }}">{{ site.name }}</option>
                             {% endfor %}
                         </select>
+                        <small class="form-text text-muted">Generates PDUs for <strong>every MDC</strong> under this site.</small>
                     </div>
                     <div class="mb-3">
-                        <label for="pduMap" class="form-label">Buildings &amp; counts</label>
-                        <input type="text" id="pduMap" name="map" class="form-control" placeholder="e.g. 10:6, 11:6">
-                        <small class="form-text text-muted">
-                            Comma-separated <code>building:count</code> pairs. <code>10:6</code> = building 10, PDUs 1–6.
-                            Or use the single-building fields below.
-                        </small>
+                        <label for="pduMdcSelect" class="form-label">Limit to one MDC (optional)</label>
+                        <select id="pduMdcSelect" name="location_id" class="form-control" disabled>
+                            <option value="">All MDCs in the site</option>
+                            {% for mdc in mdc_locations %}
+                            <option value="{{ mdc.id }}" data-site-id="{{ mdc.site_id }}">{{ mdc.get_hierarchical_display }}</option>
+                            {% endfor %}
+                        </select>
+                        <small class="form-text text-muted">Leave as “All MDCs” to do the whole site at once.</small>
                     </div>
-                    <div class="row">
-                        <div class="col-md-6 mb-3">
-                            <label for="pduBuilding" class="form-label">Building #</label>
-                            <input type="number" id="pduBuilding" name="building" class="form-control" min="1">
-                        </div>
-                        <div class="col-md-6 mb-3">
-                            <label for="pduCount" class="form-label">PDUs in building</label>
-                            <input type="number" id="pduCount" name="count" class="form-control" min="1">
-                        </div>
+                    <div class="mb-3">
+                        <label for="pduCount" class="form-label">PDUs per MDC (building) <span class="text-danger">*</span></label>
+                        <input type="number" id="pduCount" name="count" class="form-control" min="1" placeholder="e.g. 36" required>
                     </div>
                     <div id="generatePdusOutput" class="mt-3" style="display: none;">
                         <label class="form-label">Output</label>
@@ -1374,6 +1372,20 @@ $(document).ready(function() {
         });
     });
     
+    // Generate PDUs: filter the optional MDC dropdown to the chosen site.
+    $('#pduSiteSelect').on('change', function() {
+        var siteId = $(this).val();
+        var $mdc = $('#pduMdcSelect');
+        $mdc.val('');
+        $mdc.find('option').each(function() {
+            var opt = $(this);
+            if (opt.val() === '') return; // keep the "All MDCs" option
+            var match = String(opt.data('site-id')) === String(siteId);
+            opt.prop('hidden', !match).prop('disabled', !match);
+        });
+        $mdc.prop('disabled', !siteId);
+    });
+
     // Generate PDUs Form
     $('#generatePdusForm').on('submit', function(e) {
         e.preventDefault();


### PR DESCRIPTION
Addresses confusion in the Generate PDUs UX.

## What changed
An **MDC is a building**, so you no longer type a building number — it's taken from the MDC's name (e.g. *MDC 10* → `PDU 10-1`, `PDU 10-2`…).

- **Modal** now: pick a **Site** (generates for *every* MDC under it) + an optional **single-MDC** limiter + **PDUs per MDC**. Removed the building# and `building:count` map fields.
- The MDC dropdown filters to the chosen site.
- `create_pdus` command: `--site-id`/`--site` (all MDCs under the site) or `--location-id` (one MDC); building derived from the MDC name; `--count` per MDC.

## Your questions, answered
- "MDC 1 → 1:36?" → just pick the site (or MDC 1) and set count 36; building 1 is taken from the name → `PDU 1-1…1-36`.
- "Do both / whole site?" → pick the **site** and leave the MDC selector on "All MDCs" → does every MDC at once.
- "Will it recreate existing PDUs?" → **No.** Existing PDUs (by name) are skipped; re-running never duplicates or recreates.

## Verify (dev)
Locations settings → Generate PDUs → pick a site, count 36 → creates `PDU {n}-1…36` for each MDC; re-run skips them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)