### PR TITLE
style(ui): compact filter bars + headers (equipment & issues lists)

### DIFF
--- a/templates/equipment/equipment_list.html
+++ b/templates/equipment/equipment_list.html
@@ -13,26 +13,26 @@
 .equipment-header {
     background-color: #2d3748;
     border-bottom: 1px solid #4a5568;
-    padding: 15px 20px;
-    margin-bottom: 20px;
+    padding: 10px 16px;
+    margin-bottom: 12px;
 }
 
 .equipment-filters {
     display: flex;
     align-items: center;
-    gap: 15px;
+    gap: 10px;
     flex-wrap: wrap;
 }
 
 .filter-group {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
 }
 
 .filter-group label {
-    color: #e2e8f0;
-    font-size: 14px;
+    color: #a0aec0;
+    font-size: 12px;
     font-weight: 500;
     white-space: nowrap;
     margin: 0;
@@ -43,9 +43,9 @@
     color: white;
     border: 1px solid #4a5568;
     border-radius: 6px;
-    padding: 6px 12px;
-    font-size: 14px;
-    min-width: 120px;
+    padding: 4px 10px;
+    font-size: 13px;
+    min-width: 110px;
 }
 
 .filter-select:focus {
@@ -60,9 +60,9 @@
     color: white;
     border: 1px solid #4a5568;
     border-radius: 6px;
-    padding: 6px 12px;
-    font-size: 14px;
-    min-width: 200px;
+    padding: 4px 10px;
+    font-size: 13px;
+    min-width: 240px;
 }
 
 .search-input:focus {
@@ -102,10 +102,10 @@
 
 .equipment-table-header {
     background-color: #1a2238;
-    padding: 15px 20px;
+    padding: 8px 16px;
     border-bottom: 1px solid #4a5568;
     display: flex;
-    justify-content: between;
+    justify-content: space-between;
     align-items: center;
 }
 
@@ -200,20 +200,17 @@
 {% block content %}
 <!-- Equipment Filters Header -->
 <div class="equipment-header">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <div>
-            <h3 class="mb-0 text-white">
-                <i class="fas fa-cogs me-2"></i>
-                Equipment Management
-            </h3>
-            <p class="text-muted mb-0">Manage and monitor all equipment</p>
-        </div>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="mb-0 text-white">
+            <i class="fas fa-cogs me-2"></i>
+            Equipment Management
+        </h5>
         <div class="d-flex gap-2">
-            <a href="{% url 'equipment:add_equipment' %}" class="btn btn-primary">
+            <a href="{% url 'equipment:add_equipment' %}" class="btn btn-primary btn-sm">
                 <i class="fas fa-plus me-1"></i> Add Equipment
             </a>
             <div class="dropdown">
-                <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown">
+                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
                     <i class="fas fa-download me-1"></i> Import/Export
                 </button>
                 <div class="dropdown-menu">
@@ -238,14 +235,9 @@
     <!-- Filters -->
     <form method="get" class="equipment-filters">
         <div class="filter-group">
-            <label for="search">Search:</label>
-            <div>
-                <input type="text" id="search" name="search" class="search-input"
-                       value="{{ search_term }}" placeholder="Search by name, category, location, serial, tag...">
-                <small class="text-muted d-block" style="font-size: 11px; margin-top: 2px;">
-                    Searches: Equipment Name, Category, Location, Serial Number, Asset Tag, Manufacturer, Model
-                </small>
-            </div>
+            <input type="text" id="search" name="search" class="search-input"
+                   value="{{ search_term }}" placeholder="Search equipment…"
+                   title="Searches: Equipment Name, Category, Location, Serial Number, Asset Tag, Manufacturer, Model">
         </div>
         
         <div class="filter-group">

--- a/templates/equipment/issues_list.html
+++ b/templates/equipment/issues_list.html
@@ -13,17 +13,17 @@
 .issues-header {
     background-color: #2d3748;
     border-bottom: 1px solid #4a5568;
-    padding: 15px 20px;
-    margin-bottom: 20px;
+    padding: 10px 16px;
+    margin-bottom: 12px;
 }
-.issues-filters { display: flex; align-items: center; gap: 15px; flex-wrap: wrap; }
-.filter-group { display: flex; align-items: center; gap: 8px; }
-.filter-group label { color: #e2e8f0; font-size: 14px; font-weight: 500; white-space: nowrap; margin: 0; }
+.issues-filters { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.filter-group { display: flex; align-items: center; gap: 6px; }
+.filter-group label { color: #a0aec0; font-size: 12px; font-weight: 500; white-space: nowrap; margin: 0; }
 .filter-select, .search-input {
     background-color: #1a2238; color: white; border: 1px solid #4a5568;
-    border-radius: 6px; padding: 6px 12px; font-size: 14px;
+    border-radius: 6px; padding: 4px 10px; font-size: 13px;
 }
-.filter-select { min-width: 130px; }
+.filter-select { min-width: 120px; }
 .search-input { min-width: 240px; }
 .filter-select:focus, .search-input:focus {
     background-color: #1a2238; border-color: #4299e1;
@@ -32,14 +32,15 @@
 .search-input::placeholder { color: #a0aec0; }
 .action-buttons { margin-left: auto; display: flex; gap: 10px; }
 
-/* Stat cards */
-.issue-stats { display: flex; gap: 15px; flex-wrap: wrap; margin-bottom: 20px; }
+/* Stat cards (compact) */
+.issue-stats { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
 .issue-stat-card {
-    flex: 1; min-width: 150px; background-color: #2d3748; border: 1px solid #4a5568;
-    border-radius: 8px; padding: 16px 20px; text-align: center;
+    flex: 1; min-width: 120px; background-color: #2d3748; border: 1px solid #4a5568;
+    border-radius: 8px; padding: 8px 14px; text-align: center;
+    display: flex; align-items: baseline; justify-content: center; gap: 8px;
 }
-.issue-stat-card .num { font-size: 28px; font-weight: 700; line-height: 1; }
-.issue-stat-card .lbl { color: #a0aec0; font-size: 13px; margin-top: 6px; text-transform: uppercase; letter-spacing: .04em; }
+.issue-stat-card .num { font-size: 20px; font-weight: 700; line-height: 1; }
+.issue-stat-card .lbl { color: #a0aec0; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
 .issue-stat-card.open .num { color: #f56565; }
 .issue-stat-card.inprog .num { color: #ed8936; }
 .issue-stat-card.resolved .num { color: #48bb78; }
@@ -47,7 +48,7 @@
 
 .issues-table-container { background-color: #2d3748; border-radius: 8px; border: 1px solid #4a5568; overflow: hidden; }
 .issues-table-header {
-    background-color: #1a2238; padding: 15px 20px; border-bottom: 1px solid #4a5568;
+    background-color: #1a2238; padding: 8px 16px; border-bottom: 1px solid #4a5568;
     display: flex; justify-content: space-between; align-items: center;
 }
 .issues-table-header h5 { color: #e2e8f0; margin: 0; }
@@ -68,16 +69,13 @@
 
 {% block content %}
 <div class="issues-header">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <div>
-            <h3 class="mb-0 text-white">
-                <i class="fas fa-exclamation-triangle me-2"></i> Issues
-            </h3>
-            <p class="text-muted mb-0">
-                What needs to be repaired across
-                {% if selected_site %}{{ selected_site.name }}{% else %}all sites{% endif %}
-            </p>
-        </div>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="mb-0 text-white">
+            <i class="fas fa-exclamation-triangle me-2"></i> Issues
+            <small class="text-muted" style="font-size:12px; font-weight:400;">
+                — what needs repair across {% if selected_site %}{{ selected_site.name }}{% else %}all sites{% endif %}
+            </small>
+        </h5>
     </div>
 
     <!-- Stat cards -->


### PR DESCRIPTION
The list headers + filter bars used a lot of vertical space vs. the actual content. Tightened them.

## Changes
- **Header**: smaller padding/margins; title shrunk (h3 → h5); redundant subtitle folded into the title (Issues) or dropped (Equipment).
- **Filters**: denser controls + labels (smaller padding/font); removed the verbose "Searches: Equipment Name, Category, …" helper line (now the search box's tooltip).
- **Issues stat cards**: compacted into a single dense row (number + label inline) instead of tall cards.

Applied to the **equipment list** (the example) and **issues list** for consistency. Same approach can extend to the maintenance/activities and bulk-locations bars next if you want.

## Verify (dev)
Equipment & Issues pages — the top bars are noticeably shorter, more content visible; search/filters/stat-cards all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)