### PR TITLE
style(ui): compact card & page headers site-wide

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -237,8 +237,8 @@
             background-color: var(--card-bg);
             color: var(--content-text);
             border-radius: 8px;
-            padding: 20px;
-            margin-bottom: 20px;
+            padding: 12px 16px;
+            margin-bottom: 14px;
             border: 1px solid var(--card-border);
         }
         
@@ -368,11 +368,13 @@
             border-radius: 8px;
             color: var(--content-text);
         }
-        
+
+        /* Compact card headers (filter/list bars) site-wide */
         .card-header {
             background-color: var(--nav-bg);
             border-bottom: 1px solid var(--card-border);
             color: var(--nav-text);
+            padding: 0.5rem 1rem;
         }
         
         .card-body {


### PR DESCRIPTION
Finishes the "across site" compaction. Rather than edit 40+ templates, this tightens the **shared containers** in `base.html` so list/filter bars shrink everywhere at once:

- `.card-header` padding → `0.5rem 1rem` (Bootstrap's default was bulky) — compacts the filter/search bars on **maintenance activities, schedules, reports, category/global schedules, user management**, etc. (they all use card-headers).
- `.page-header` padding `20px → 12px 16px`, margin-bottom `20px → 14px`.

Complements #137 (equipment/issues lists, which use bespoke classes and were compacted directly).

## Verify (dev)
Across the maintenance/schedule/report list pages, the header/filter bars are noticeably shorter; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)