### PR TITLE
fix(mobile): nav dropdowns overlap items in collapsed menu (SSDEV-29)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -925,14 +925,28 @@
                 padding: 12px 16px;
                 border-bottom: 1px solid var(--card-border);
             }
-            /* Dropdowns render inline within the collapsed menu */
+            /* Dropdowns render inline within the collapsed menu. Popper.js sets
+               inline position/transform/top/left to float the menu — override
+               them so the items flow in-line and don't overlap the nav below. */
             .nav-tabs-custom .dropdown-menu {
                 position: static !important;
+                transform: none !important;
+                top: auto !important;
+                left: auto !important;
+                right: auto !important;
+                inset: auto !important;
                 float: none;
                 width: 100%;
+                max-height: none;
+                margin: 0 !important;
                 border: none;
                 box-shadow: none;
-                padding-left: 24px;
+                padding: 0;
+                background-color: rgba(0, 0, 0, 0.18);
+            }
+            .nav-tabs-custom .dropdown-menu .dropdown-item {
+                padding: 10px 16px 10px 44px;
+                border-bottom: 1px solid var(--card-border);
             }
 
             /* Tables: size to content and scroll horizontally instead of


### PR DESCRIPTION
Closes the mobile-menu spacing bug (SSDEV-29).

## Cause
In the collapsed mobile menu, opening a nav dropdown (Equipment/Maintenance/Settings) floated its menu **over** the items below ("Add Equipment"/"Manage" landing on "Maintenance"). The mobile rule set `position: static`, but **Popper.js** still set inline `transform`/`top`/`left`, shifting the menu down onto the next items.

## Fix
In the `≤991.98px` media query, override Popper's inline geometry (`transform/top/left/right/inset/margin → none/auto !important`) so dropdown items flow **inline** beneath their parent. Indented + divided sub-items for hierarchy.

## Verify (mobile)
Open the hamburger menu → tap Equipment/Maintenance/Settings → the sub-items expand inline and push the rest of the menu down; nothing overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)