### PR TITLE
feat(equipment): retire moves unit to site Archive sublocation (SSDEV-27)

### DIFF
--- a/equipment/models.py
+++ b/equipment/models.py
@@ -249,13 +249,38 @@ class Equipment(TimeStampedModel):
         return None
     
     def save(self, *args, **kwargs):
-        """Override save to automatically apply category schedules."""
+        """Override save to apply category schedules and, when a unit is retired,
+        relocate it to its site's "Archive" sublocation."""
         is_new = self.pk is None
+
+        # On transition to 'retired', move the unit into the site's Archive
+        # sublocation (created on demand). Bulk .update() bypasses save() and is
+        # not affected — retirement normally goes through the edit form/admin.
+        if not is_new and self.status == 'retired':
+            prev = Equipment.objects.filter(pk=self.pk).only('status').first()
+            if prev and prev.status != 'retired':
+                archive = self._get_or_create_archive_location()
+                if archive and self.location_id != archive.id:
+                    self.location = archive
+
         super().save(*args, **kwargs)
-        
+
         # Apply category schedules for new equipment
         if is_new:
             self.apply_category_schedules()
+
+    def _get_or_create_archive_location(self):
+        """Return this equipment's site-level "Archive" sublocation, creating it
+        under the site if it doesn't exist. Returns None if there's no site."""
+        site = self.get_site()
+        if not site:
+            return None
+        from core.models import Location
+        archive, _ = Location.objects.get_or_create(
+            name='Archive', parent_location=site, is_site=False,
+            defaults={'is_active': True},
+        )
+        return archive
 
     def clean(self):
         """Custom validation for equipment."""


### PR DESCRIPTION
Closes **SSDEV-27**.

## Behavior
When a unit's status changes to **Retired**, it's moved into an **"Archive"** sublocation under its site (created automatically the first time). This pulls retired units out of their POD/MDC so they stop cluttering the active equipment views and the facility map.

## Implementation
- `Equipment.save()` detects the transition to `retired` (only for existing records; skips if already retired). New records and bulk `.update()` are unaffected — retirement normally goes through the edit form/admin.
- `_get_or_create_archive_location()` finds/creates `Archive` (is_site=False) under the unit's site via `get_site()`.
- **No migration** — Archive is just a Location row created at runtime.

## Verify (dev)
Edit a unit → set Status = Retired → Save → its location becomes `‹site› > Archive` (the Archive location is created if it didn't exist). Retiring another unit reuses the same Archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)