### PR TITLE
security(rbac): enforce permissions on destructive + CRUD endpoints

### DIFF
--- a/core/views/debug_data.py
+++ b/core/views/debug_data.py
@@ -7,6 +7,7 @@ from equipment.models import Equipment
 from maintenance.models import MaintenanceActivity
 from events.models import CalendarEvent
 from core.models import Location, EquipmentCategory, Role, Permission, UserProfile, Customer, BrandingSettings, DashboardSettings, CSSCustomization
+from core.rbac import permission_required
 from core.forms import LocationForm, EquipmentCategoryForm, CustomerForm, UserForm, BrandingSettingsForm, BrandingBasicForm, BrandingNavigationForm, BrandingAppearanceForm, CSSCustomizationForm, CSSPreviewForm, DashboardSettingsForm
 from django.utils import timezone
 from django.db.models import Q, Count
@@ -43,8 +44,7 @@ from django.utils import timezone
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
 
 
-@login_required
-@user_passes_test(lambda u: u.is_superuser)
+@permission_required('admin.full_access')
 def clear_maintenance_data(request):
     """Clear all maintenance activities and calendar events (superuser only)."""
     if request.method == 'POST':
@@ -103,8 +103,7 @@ def clear_maintenance_data(request):
     return render(request, 'core/clear_data_confirm.html', context)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 @require_http_methods(["POST"])
 def generate_pdus(request):
     """Generate PDU equipment ("PDU {building}-{n}") under an MDC location.
@@ -148,8 +147,7 @@ def generate_pdus(request):
         }, status=500)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 @require_http_methods(["POST"])
 def generate_pods(request):
     """Generate PODs for selected sites or all sites."""
@@ -225,8 +223,7 @@ def generate_pods(request):
         }, status=500)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 @require_http_methods(["POST"])
 def generate_mdcs(request):
     """Generate MDCs for existing PODs."""
@@ -379,8 +376,7 @@ def generate_mdcs(request):
         }, status=500)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('admin.full_access')
 @require_http_methods(["POST"])
 def populate_demo_data(request):
     """Populate the database with comprehensive demo data."""
@@ -445,8 +441,7 @@ def populate_demo_data(request):
         }, status=500)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('admin.full_access')
 @require_http_methods(["POST"])
 def clear_maintenance_activities(request):
     """Clear scheduled maintenance activities without wiping entire database (web interface version)."""
@@ -521,8 +516,7 @@ def clear_maintenance_activities(request):
 
 
 @login_required
-@user_passes_test(is_staff_or_superuser)
-@csrf_exempt
+@permission_required('admin.full_access')
 @require_http_methods(["POST"])
 def clear_database(request):
     """Clear the database with safety confirmations."""

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -518,8 +518,7 @@ def location_detail_api(request, location_id):
             }, status=500)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 def add_location(request):
     """Add new location."""
     if request.method == 'POST':
@@ -545,8 +544,7 @@ def add_location(request):
     return render(request, 'core/add_location.html', context)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 def edit_location(request, location_id):
     """Edit existing location."""
     location = get_object_or_404(Location, id=location_id)
@@ -610,7 +608,7 @@ def export_sites_csv(request):
     return response
 
 
-@login_required
+@permission_required('site_map.write')
 @require_http_methods(["POST"])
 def import_sites_csv(request):
     """Import sites data from CSV file."""
@@ -702,8 +700,7 @@ def import_sites_csv(request):
     return redirect('core:locations_settings')
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 def delete_location(request, location_id):
     """Delete location."""
     location = get_object_or_404(Location, id=location_id)
@@ -782,7 +779,7 @@ def export_locations_csv(request):
     return response
 
 
-@login_required
+@permission_required('site_map.write')
 @require_http_methods(["POST"])
 def import_locations_csv(request):
     """Import locations (map data) from CSV file."""
@@ -943,7 +940,7 @@ def import_locations_csv(request):
 
 
 @login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('site_map.write')
 @require_http_methods(["GET", "POST"])
 def bulk_edit_locations(request):
     """Bulk edit locations (sites and sub-locations)."""

--- a/core/views/users_roles.py
+++ b/core/views/users_roles.py
@@ -41,10 +41,10 @@ import redis
 from django_celery_beat.models import PeriodicTask
 from django.utils import timezone
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
+from core.rbac import permission_required
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('users.manage')
 def user_management(request):
     """Enhanced user management view with role assignment."""
     if request.method == 'POST':
@@ -110,8 +110,7 @@ def user_management(request):
     return render(request, 'core/user_management.html', context)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('users.manage')
 def add_user(request):
     """Add new user."""
     if request.method == 'POST':
@@ -131,8 +130,7 @@ def add_user(request):
     return render(request, 'core/user_form.html', context)
 
 
-@login_required
-@user_passes_test(is_staff_or_superuser)
+@permission_required('users.manage')
 def edit_user(request, user_id):
     """Edit existing user."""
     user = get_object_or_404(User, id=user_id)

--- a/equipment/views.py
+++ b/equipment/views.py
@@ -612,7 +612,7 @@ def equipment_kpi_tracker(request, equipment_id):
     return render(request, 'equipment/kpi_tracker.html', context)
 
 
-@login_required
+@permission_required('equipment.create')
 def add_equipment(request):
     """Add new equipment (improved from original web2py version)."""
     if request.method == 'POST':
@@ -649,7 +649,7 @@ def add_equipment(request):
     return render(request, 'equipment/add_equipment.html', context)
 
 
-@login_required
+@permission_required('equipment.edit')
 def edit_equipment(request, equipment_id):
     """Edit existing equipment."""
     equipment = get_object_or_404(Equipment, id=equipment_id)
@@ -697,7 +697,7 @@ def edit_equipment(request, equipment_id):
     return render(request, 'equipment/edit_equipment.html', context)
 
 
-@login_required
+@permission_required('equipment.delete')
 @require_http_methods(["POST"])
 def delete_equipment(request, equipment_id):
     """Delete equipment (AJAX endpoint)."""
@@ -850,7 +850,7 @@ def equipment_components(request, equipment_id):
     return render(request, 'equipment/equipment_components.html', context)
 
 
-@login_required
+@permission_required('equipment.edit')
 def add_component(request, equipment_id):
     """Add component to equipment."""
     equipment = get_object_or_404(Equipment, id=equipment_id)
@@ -977,7 +977,7 @@ def delete_document(request, equipment_id, document_id):
 
 
 
-@login_required
+@permission_required('site_map.write')
 def import_locations_csv(request):
     """Import locations from CSV file."""
     if request.method == 'POST':
@@ -1149,7 +1149,7 @@ def export_equipment_csv(request):
     return response
 
 
-@login_required
+@permission_required('equipment.create')
 @require_http_methods(["POST"])
 def import_equipment_csv(request):
     """Import equipment data from CSV file."""
@@ -2366,7 +2366,7 @@ def delete_connection(request, connection_id):
         }, status=500)
 
 
-@login_required
+@permission_required('issues.create')
 def log_issue(request, equipment_id):
     """Log a new issue for equipment. Supports both regular POST and AJAX."""
     equipment = get_object_or_404(Equipment, id=equipment_id)
@@ -2541,7 +2541,7 @@ def delete_issue(request, equipment_id, issue_id):
     return redirect('equipment:equipment_detail', equipment_id=equipment_id)
 
 
-@login_required
+@permission_required('maintenance.create')
 def create_maintenance_from_issue(request, equipment_id, issue_id):
     """Create a corrective maintenance activity from an equipment issue."""
     from maintenance.models import MaintenanceActivityType, ActivityTypeCategory

--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -41,6 +41,7 @@ from django.contrib.auth.models import User
 from core.models import Location
 from core.utils import get_all_descendant_location_ids  # noqa: F401
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
+from core.rbac import permission_required
 
 
 @login_required
@@ -321,7 +322,7 @@ def activity_list(request):
             return redirect('maintenance:maintenance_list')
 
 
-@login_required
+@permission_required('maintenance.create')
 def bulk_add_activity(request):
     """Bulk create maintenance activities for multiple equipment items."""
     from django.db import connection, transaction
@@ -659,7 +660,7 @@ def activity_detail(request, activity_id):
     return render(request, 'maintenance/activity_detail.html', context)
 
 
-@login_required
+@permission_required('maintenance.create')
 def add_activity(request):
     """Add new maintenance activity with improved database connection handling."""
     from django.db import connection
@@ -778,7 +779,7 @@ def add_activity(request):
             return redirect('maintenance:maintenance_list')
 
 
-@login_required
+@permission_required('maintenance.edit')
 def edit_activity(request, activity_id):
     """Edit maintenance activity."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)
@@ -804,7 +805,7 @@ def edit_activity(request, activity_id):
     return render(request, 'maintenance/edit_activity.html', context)
 
 
-@login_required
+@permission_required('maintenance.complete')
 def complete_activity(request, activity_id):
     """Mark maintenance activity as completed."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)
@@ -838,7 +839,7 @@ def overdue_maintenance(request):
     return render(request, 'maintenance/overdue_maintenance.html', context)
 
 
-@login_required
+@permission_required('maintenance.delete')
 def delete_activity(request, activity_id):
     """Delete maintenance activity and associated calendar events."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)
@@ -880,7 +881,7 @@ def delete_activity(request, activity_id):
     return render(request, 'maintenance/delete_activity.html', context)
 
 
-@login_required
+@permission_required('maintenance.delete')
 def bulk_delete_activities(request):
     """Delete multiple maintenance activities selected on the activity list."""
     if request.method != 'POST':

--- a/maintenance/views/schedules.py
+++ b/maintenance/views/schedules.py
@@ -41,6 +41,7 @@ from django.contrib.auth.models import User
 from core.models import Location
 from core.utils import get_all_descendant_location_ids  # noqa: F401
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
+from core.rbac import permission_required
 
 
 @login_required
@@ -73,7 +74,7 @@ def schedule_list(request):
             return redirect('maintenance:maintenance_list')
 
 
-@login_required
+@permission_required('maintenance.create')
 def add_schedule(request):
     """Add new maintenance schedule."""
     if request.method == 'POST':
@@ -119,7 +120,7 @@ def schedule_detail(request, schedule_id):
     return render(request, 'maintenance/schedule_detail.html', context)
 
 
-@login_required
+@permission_required('maintenance.edit')
 def edit_schedule(request, schedule_id):
     """Edit maintenance schedule."""
     schedule = get_object_or_404(MaintenanceSchedule, id=schedule_id)
@@ -169,7 +170,7 @@ def edit_schedule(request, schedule_id):
     return render(request, 'maintenance/edit_schedule.html', context)
 
 
-@login_required
+@permission_required('maintenance.create')
 def generate_scheduled_activities(request):
     """Generate maintenance activities from schedules."""
     if request.method == 'POST':
@@ -207,7 +208,7 @@ def generate_scheduled_activities(request):
     return render(request, 'maintenance/generate_activities.html', context)
 
 
-@login_required
+@permission_required('maintenance.delete')
 def delete_schedule(request, schedule_id):
     """Delete maintenance schedule."""
     schedule = get_object_or_404(MaintenanceSchedule, id=schedule_id)
@@ -282,7 +283,7 @@ def category_schedule_list(request):
         return render(request, 'maintenance/category_schedule_list.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def add_category_schedule(request):
     """Add new equipment category schedule."""
     if request.method == 'POST':
@@ -304,7 +305,7 @@ def add_category_schedule(request):
     return render(request, 'maintenance/category_schedule_form.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def edit_category_schedule(request, schedule_id):
     """Edit equipment category schedule."""
     schedule = get_object_or_404(EquipmentCategorySchedule, id=schedule_id)
@@ -378,7 +379,7 @@ def global_schedule_list(request):
         return render(request, 'maintenance/global_schedule_list.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def add_global_schedule(request):
     """Add new global schedule."""
     if request.method == 'POST':
@@ -400,7 +401,7 @@ def add_global_schedule(request):
     return render(request, 'maintenance/global_schedule_form.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def edit_global_schedule(request, schedule_id):
     """Edit global schedule."""
     schedule = get_object_or_404(GlobalSchedule, id=schedule_id)
@@ -470,7 +471,7 @@ def schedule_override_list(request):
         return render(request, 'maintenance/schedule_override_list.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def add_schedule_override(request):
     """Add new schedule override."""
     if request.method == 'POST':
@@ -495,7 +496,7 @@ def add_schedule_override(request):
     return render(request, 'maintenance/schedule_override_form.html', context)
 
 
-@login_required
+@permission_required('maintenance.manage_all')
 def edit_schedule_override(request, override_id):
     """Edit schedule override."""
     override = get_object_or_404(ScheduleOverride, id=override_id)


### PR DESCRIPTION
The RBAC system existed but was barely used — most state-changing views only checked `@login_required`, and locations/users used Django's `is_staff_or_superuser` instead of role permissions. This standardizes on `@permission_required`.

## Destructive / admin (`core/views/debug_data.py`)
- **`clear_database`**: removed `@csrf_exempt` (both callers send `X-CSRFToken`, so it stays functional) + now requires `admin.full_access`.
- `clear_maintenance_data`, `clear_maintenance_activities`, `populate_demo_data` → `admin.full_access`.
- `generate_pods` / `generate_mdcs` / `generate_pdus` → `site_map.write`.

## CRUD
- **Equipment**: add→`equipment.create`, edit/add_component→`equipment.edit`, delete→`equipment.delete`, CSV import→`equipment.create`, `import_locations_csv`→`site_map.write`, `log_issue`→`issues.create`, `create_maintenance_from_issue`→`maintenance.create`.
- **Maintenance**: add/bulk-add→`maintenance.create`, edit→`maintenance.edit`, complete→`maintenance.complete`, delete/bulk-delete→`maintenance.delete`; schedule add/edit/delete→`maintenance.create/edit/delete`; category/global/override schedule CRUD→`maintenance.manage_all`.
- **Locations**: add/edit/delete/import/bulk → `site_map.write` (was `is_staff_or_superuser`).
- **Users**: management/add/edit → `users.manage` (was `is_staff_or_superuser`).

## Notes
- **Superusers bypass** all checks (prod admin unaffected).
- The default **manager/technician/viewer** roles already carry the relevant perms; **delete** and **manage_all** are admin/manager-level *by role design*, so e.g. technicians can't delete — adjust roles if you want different.
- Permissions must exist in the DB (`initialize_default_permissions`). For AJAX endpoints, denial returns a 403 JSON; for pages, a redirect to dashboard with a message.
- **Deferred** (the "everything" tier): customers/equipment-category/events CRUD and read-only/list/settings views still use their existing `@login_required` / `is_staff_or_superuser`.

## Verify (dev)
As superuser/admin: everything works. As a `viewer`: add/edit/delete/generate/clear actions are blocked (403/redirect); reads still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)