### PR TITLE
fix(debug): Database Statistics wrong URL (/core/ prefix → 404 HTML)

### DIFF
--- a/templates/core/debug.html
+++ b/templates/core/debug.html
@@ -500,7 +500,7 @@ function loadDatabaseStats() {
     document.getElementById('database-stats').innerHTML = statsHtml;
     
     // Fetch actual stats
-    fetch('/core/api/database-stats/', {
+    fetch('{% url "core:database_stats_api" %}', {
         credentials: 'same-origin',
         headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
The Debug page's Database Statistics call used a hardcoded `/core/api/database-stats/`, but `core.urls` is mounted at **root**, so the real route is `/api/database-stats/`. The bad path 404'd to an HTML page → the red **"Unexpected response type: text/html"**. Switched to `{% url 'core:database_stats_api' %}`.

(Pre-existing, not from the RBAC push. The empty *System Health* table is a separate data-shape issue in `health_check_api` — can chase if wanted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)