### PR TITLE
fix(debug): populate System Health table (response shape mismatch)

### DIFF
--- a/templates/core/debug.html
+++ b/templates/core/debug.html
@@ -460,21 +460,39 @@ function loadHealthStatus() {
         .then(response => response.json())
         .then(data => {
             let html = '<table class="data-table"><thead><tr><th>Component</th><th>Status</th><th>Details</th></tr></thead><tbody>';
-            
-            if (data.checks && Array.isArray(data.checks)) {
-                data.checks.forEach(check => {
-                    const statusClass = check.status === 'success' ? 'success' : check.status === 'error' ? 'danger' : 'warning';
-                    const indicatorClass = check.status === 'success' ? 'healthy' : check.status === 'error' ? 'error' : 'warning';
+
+            // comprehensive_health_check returns { components: { name: {status, ...} } }
+            const comps = data.components || {};
+            const entries = Object.entries(comps);
+            if (entries.length === 0) {
+                html += '<tr><td colspan="3" class="text-muted">No health data available</td></tr>';
+            } else {
+                entries.forEach(([key, comp]) => {
+                    comp = comp || {};
+                    const status = comp.status || 'unknown';
+                    const healthy = status === 'healthy' || status === 'ok';
+                    const bad = status === 'unhealthy' || status === 'critical' || status === 'error';
+                    const statusClass = healthy ? 'success' : bad ? 'danger' : 'warning';
+                    const indicatorClass = healthy ? 'healthy' : bad ? 'error' : 'warning';
+                    let detail = comp.message || comp.error || comp.output || '';
+                    if (!detail) {
+                        detail = Object.entries(comp)
+                            .filter(([k, v]) => k !== 'status' && (typeof v === 'string' || typeof v === 'number'))
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(', ');
+                    }
+                    if (detail.length > 160) detail = detail.slice(0, 157) + '…';
+                    const name = key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
                     html += `
                         <tr>
-                            <td><span class="health-indicator ${indicatorClass}"></span>${check.name}</td>
-                            <td><span class="badge bg-${statusClass}">${check.status}</span></td>
-                            <td><small>${check.message || '-'}</small></td>
+                            <td><span class="health-indicator ${indicatorClass}"></span>${name}</td>
+                            <td><span class="badge bg-${statusClass}">${status}</span></td>
+                            <td><small>${detail || '-'}</small></td>
                         </tr>
                     `;
                 });
             }
-            
+
             html += '</tbody></table>';
             document.getElementById('health-status').innerHTML = html;
         })


### PR DESCRIPTION
The **System Health** table was empty because the JS expected \`data.checks\` (an array of \`{name,status,message}\`) and colored on \`success\`/\`error\`, but \`core:health_check_api\` → \`comprehensive_health_check\` actually returns \`{ components: { database/cache/celery_worker/celery_beat/system: {status, ...} } }\` with statuses \`healthy\`/\`unhealthy\`/\`warning\`. The loop never matched, so no rows rendered.

## Fix
Rewrote the table builder to iterate \`data.components\`:
- map `healthy`→green, `unhealthy`/`critical`/`error`→red, else amber;
- details from `message`/`error`/`output`, falling back to the component's scalar fields (truncated);
- prettified component names + explicit empty state.

## Verify (dev)
Debug → System Health now lists Database / Cache / Celery Worker / Celery Beat / System with status badges + details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)