### PR TITLE
feat(nav): add Schedules to the Maintenance dropdown

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1074,6 +1074,7 @@
                  </a>
                 <div class="dropdown-menu">
                     <a class="dropdown-item" href="{% url 'maintenance:maintenance_list' %}">Activities</a>
+                    <a class="dropdown-item" href="{% url 'maintenance:schedule_list' %}">Schedules</a>
                     <a class="dropdown-item" href="{% url 'maintenance:maintenance_reports' %}">Reports</a>
                 </div>
             </li>


### PR DESCRIPTION
Adds a **Schedules** item to the Maintenance nav dropdown (Activities / Schedules / Reports), linking to `maintenance:schedule_list`. Previously the schedule list was only reachable via deep links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)