### PR TITLE
fix/style(maintenance): accurate Pending stat + concise dashboard

### DIFF
--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -117,7 +117,10 @@ def maintenance_list(request):
         
         stats = {
             'total_activities': stats_queryset.count(),
-            'pending_count': stats_queryset.filter(status='pending').count(),
+            # "Pending" = open/upcoming work; activities default to 'scheduled',
+            # so counting only 'pending' badly undercounts.
+            'pending_count': stats_queryset.filter(status__in=['scheduled', 'pending']).count(),
+            'in_progress_count': stats_queryset.filter(status='in_progress').count(),
             'overdue_count': overdue_activities.count(),
             'completed_this_month': stats_queryset.filter(
                 status='completed',
@@ -198,7 +201,8 @@ def maintenance_list(request):
             
             stats = {
                 'total_activities': stats_queryset.count(),
-                'pending_count': stats_queryset.filter(status='pending').count(),
+                'pending_count': stats_queryset.filter(status__in=['scheduled', 'pending']).count(),
+                'in_progress_count': stats_queryset.filter(status='in_progress').count(),
                 'overdue_count': overdue_activities.count(),
                 'completed_this_month': stats_queryset.filter(
                     status='completed',

--- a/templates/maintenance/maintenance_list.html
+++ b/templates/maintenance/maintenance_list.html
@@ -9,84 +9,49 @@
 {% endblock %}
 
 {% block content %}
-<div class="row">
-    <div class="col-12">
-        <div class="page-header">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    <h1 class="h3 mb-0">
-                        <i class="fas fa-calendar-check me-2"></i>
-                        Maintenance Activities
-                    </h1>
-                    <p class="text-muted mb-0">Manage and track maintenance activities</p>
-                </div>
-
-            </div>
-        </div>
+<!-- Header + actions -->
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+    <h1 class="h4 mb-0"><i class="fas fa-calendar-check me-2"></i>Maintenance Activities</h1>
+    <div class="d-flex gap-2 flex-wrap">
+        <a href="{% url 'maintenance:add_activity' %}" class="btn btn-primary btn-sm"><i class="fas fa-plus me-1"></i> New</a>
+        <a href="{% url 'maintenance:bulk_add_activity' %}" class="btn btn-success btn-sm"><i class="fas fa-layer-group me-1"></i> Bulk Create</a>
+        <a href="{% url 'maintenance:activity_list' %}" class="btn btn-outline-primary btn-sm"><i class="fas fa-list me-1"></i> All Activities</a>
+        <a href="{% url 'maintenance:schedule_list' %}" class="btn btn-outline-secondary btn-sm"><i class="fas fa-calendar-alt me-1"></i> Schedules</a>
+        <a href="{% url 'maintenance:maintenance_reports' %}" class="btn btn-outline-info btn-sm"><i class="fas fa-chart-bar me-1"></i> Reports</a>
     </div>
 </div>
 
-<!-- Statistics Cards -->
-<div class="row mb-4">
-    <div class="col-md-3">
-        <div class="card">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="text-muted">Total Activities</h6>
-                        <h3 class="mb-0">{{ stats.total_activities }}</h3>
-                    </div>
-                    <div class="text-primary">
-                        <i class="fas fa-tasks fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+<!-- KPI strip -->
+<div class="row g-2 mb-3">
+    <div class="col-6 col-md">
+        <div class="card h-100"><div class="card-body py-2 d-flex justify-content-between align-items-center">
+            <div><div class="text-muted text-uppercase" style="font-size:11px;">Total</div><div class="h4 mb-0">{{ stats.total_activities }}</div></div>
+            <i class="fas fa-tasks text-primary"></i>
+        </div></div>
     </div>
-    <div class="col-md-3">
-        <div class="card">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="text-muted">Pending</h6>
-                        <h3 class="mb-0 text-warning">{{ stats.pending_count }}</h3>
-                    </div>
-                    <div class="text-warning">
-                        <i class="fas fa-clock fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="col-6 col-md">
+        <div class="card h-100"><div class="card-body py-2 d-flex justify-content-between align-items-center">
+            <div><div class="text-muted text-uppercase" style="font-size:11px;">Pending</div><div class="h4 mb-0 text-warning">{{ stats.pending_count }}</div></div>
+            <i class="fas fa-clock text-warning"></i>
+        </div></div>
     </div>
-    <div class="col-md-3">
-        <div class="card">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="text-muted">Overdue</h6>
-                        <h3 class="mb-0 text-danger">{{ stats.overdue_count }}</h3>
-                    </div>
-                    <div class="text-danger">
-                        <i class="fas fa-exclamation-triangle fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="col-6 col-md">
+        <div class="card h-100"><div class="card-body py-2 d-flex justify-content-between align-items-center">
+            <div><div class="text-muted text-uppercase" style="font-size:11px;">In Progress</div><div class="h4 mb-0 text-info">{{ stats.in_progress_count }}</div></div>
+            <i class="fas fa-play-circle text-info"></i>
+        </div></div>
     </div>
-    <div class="col-md-3">
-        <div class="card">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="text-muted">Completed This Month</h6>
-                        <h3 class="mb-0 text-success">{{ stats.completed_this_month }}</h3>
-                    </div>
-                    <div class="text-success">
-                        <i class="fas fa-check-circle fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="col-6 col-md">
+        <div class="card h-100"><div class="card-body py-2 d-flex justify-content-between align-items-center">
+            <div><div class="text-muted text-uppercase" style="font-size:11px;">Overdue</div><div class="h4 mb-0 text-danger">{{ stats.overdue_count }}</div></div>
+            <i class="fas fa-exclamation-triangle text-danger"></i>
+        </div></div>
+    </div>
+    <div class="col-6 col-md">
+        <div class="card h-100"><div class="card-body py-2 d-flex justify-content-between align-items-center">
+            <div><div class="text-muted text-uppercase" style="font-size:11px;">Completed (mo)</div><div class="h4 mb-0 text-success">{{ stats.completed_this_month }}</div></div>
+            <i class="fas fa-check-circle text-success"></i>
+        </div></div>
     </div>
 </div>
 
@@ -260,53 +225,6 @@
 </div>
 {% endif %}
 
-<!-- Quick Actions -->
-<div class="row mt-4">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="mb-0">
-                    <i class="fas fa-bolt me-2"></i>
-                    Quick Actions
-                </h5>
-            </div>
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-3">
-                        <a href="{% url 'maintenance:add_activity' %}" class="btn btn-primary btn-block">
-                            <i class="fas fa-plus me-2"></i>
-                            New Activity
-                        </a>
-                    </div>
-                    <div class="col-md-3">
-                        <a href="{% url 'maintenance:bulk_add_activity' %}" class="btn btn-success btn-block">
-                            <i class="fas fa-layer-group me-2"></i>
-                            Bulk Create
-                        </a>
-                    </div>
-                    <div class="col-md-3">
-                        <a href="{% url 'maintenance:activity_list' %}" class="btn btn-outline-primary btn-block">
-                            <i class="fas fa-list me-2"></i>
-                            View All Activities
-                        </a>
-                    </div>
-                    <div class="col-md-3">
-                        <a href="{% url 'maintenance:schedule_list' %}" class="btn btn-outline-secondary btn-block">
-                            <i class="fas fa-calendar-alt me-2"></i>
-                            Schedules
-                        </a>
-                    </div>
-                    <div class="col-md-3">
-                        <a href="{% url 'maintenance:maintenance_reports' %}" class="btn btn-outline-info btn-block">
-                            <i class="fas fa-chart-bar me-2"></i>
-                            Reports
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Bug
The **Pending** stat counted only \`status='pending'\`, but activities default to \`scheduled\` — so it read ~0 even with lots of open work. Now counts **scheduled + pending**, and added an **In Progress** stat. Fixed in both the primary and DB-fallback stat blocks.

## Clunk
- **Compact header** with the actions moved into it (New / Bulk Create / All Activities / Schedules / Reports as `sm` buttons) — removed the big bottom **Quick Actions** card.
- **Slim 5-up KPI strip** (Total / Pending / In Progress / Overdue / Completed-mo) replacing the tall icon cards with lots of dead space.
- Upcoming / Overdue / In-Progress tables unchanged.

## Verify (dev)
Maintenance → Activities (with a site selected): Pending now reflects scheduled+pending; compact KPI row; actions in the header; no giant Quick Actions block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)