### PR TITLE
fix(map): show all equipment (drop is_active filter)

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -100,8 +100,12 @@ def _build_site_layout(site):
     pod_ids = {p.id for p in pods}
 
     site_loc_ids = get_all_descendant_location_ids(site, include_inactive=True)
+    # Show ALL equipment under the site (matching the equipment list, which does
+    # not filter on is_active). Filtering is_active=True here hid equipment that
+    # was wrongly deactivated by the old edit bug — visible on the list but not
+    # the map. Coloring is driven by operational status, not is_active.
     equipment = list(
-        Equipment.objects.filter(location_id__in=site_loc_ids, is_active=True)
+        Equipment.objects.filter(location_id__in=site_loc_ids)
         .select_related('location', 'category')
     )
     eq_ids = [e.id for e in equipment]


### PR DESCRIPTION
## Bug
Equipment shows on the **Equipment list** but is missing from the **Facility Map** (e.g. POD 3 has MT9923 on the list, but the map shows POD 3 empty).

## Cause
The map's equipment query filtered \`is_active=True\`; the equipment list does **not**. Units wrongly deactivated by the old edit bug (#118) are therefore visible on the list but hidden from the map.

## Fix
Drop the \`is_active=True\` filter in \`_build_site_layout\` so the map shows the same equipment as the list. Coloring is still driven by operational **status** (so retired/inactive show grey, not hidden).

Complementary cleanup: running \`reactivate_equipment\` on prod restores the \`is_active\` flag for the pickers/calendar that still filter on it.

## Verify (dev/prod)
Map → POD 3 now shows MT9923 (and other previously-hidden units appear in their PODs/MDCs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)