### PR TITLE
fix(data): reactivate equipment wrongly deactivated (migration)

### DIFF
--- a/equipment/migrations/0022_reactivate_misdeactivated_equipment.py
+++ b/equipment/migrations/0022_reactivate_misdeactivated_equipment.py
@@ -1,0 +1,30 @@
+# Data fix: the old edit form omitted is_active, so saving an equipment silently
+# set is_active=False and hid it from the maintenance/calendar pickers (and,
+# until recently, the map). Reactivate units that are clearly still in service —
+# is_active=False but operational status active/maintenance. Retired/inactive
+# status equipment is left alone (may be deactivated on purpose). Idempotent.
+
+from django.db import migrations
+
+
+def reactivate(apps, schema_editor):
+    Equipment = apps.get_model('equipment', 'Equipment')
+    Equipment.objects.filter(
+        is_active=False, status__in=['active', 'maintenance']
+    ).update(is_active=True)
+
+
+def noop(apps, schema_editor):
+    # No reverse — we don't know which units were intentionally inactive before.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('equipment', '0021_equipment_layout_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(reactivate, noop),
+    ]


### PR DESCRIPTION
Auto-fixes the \`is_active\` data on deploy instead of a manual \`reactivate_equipment\` run.

Data migration (`equipment/0022`) sets \`is_active=True\` for units that are \`is_active=False\` but whose **operational status is active/maintenance** — i.e. clearly still in service and wrongly hidden by the old edit-form bug (#118). Retired/inactive-status equipment is left alone. Idempotent; no-op reverse.

Runs via the deploy \`migrate\` step, so the maintenance/calendar pickers (which still filter \`is_active\`) see the equipment again — complements the map fix (#151) which now shows all equipment regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)