### PR TITLE
feat(maintenance): sortable columns + page size + shift-select on activity list

### DIFF
--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -260,11 +260,38 @@ def activity_list(request):
                 Q(activity_type__name__icontains=search_term)
             )
         
-        # Pagination
-        paginator = Paginator(queryset, 25)
-        page_number = request.GET.get('page')
-        page_obj = paginator.get_page(page_number)
-        
+        # Sorting (whitelisted columns)
+        SORT_MAP = {
+            'title': 'title', 'equipment': 'equipment__name',
+            'activity_type': 'activity_type__name', 'scheduled_start': 'scheduled_start',
+            'status': 'status', 'priority': 'priority', 'assigned_to': 'assigned_to__username',
+        }
+        sort = request.GET.get('sort', '-scheduled_start')
+        field = sort[1:] if sort.startswith('-') else sort
+        if field in SORT_MAP:
+            order = ('-' if sort.startswith('-') else '') + SORT_MAP[field]
+        else:
+            sort, order = '-scheduled_start', '-scheduled_start'
+        queryset = queryset.order_by(order)
+
+        # Page size
+        try:
+            per_page = int(request.GET.get('per_page', 25))
+        except (TypeError, ValueError):
+            per_page = 25
+        if per_page not in (25, 50, 100, 200):
+            per_page = 25
+
+        paginator = Paginator(queryset, per_page)
+        page_obj = paginator.get_page(request.GET.get('page'))
+
+        # Querystrings for pagination/sort links (preserve filters)
+        params = request.GET.copy()
+        params.pop('page', None)
+        base_qs = params.urlencode()
+        params.pop('sort', None)
+        sort_qs = params.urlencode()
+
         context = {
             'page_obj': page_obj,
             'search_term': search_term,
@@ -274,8 +301,17 @@ def activity_list(request):
             'selected_status': status,
             'selected_equipment': equipment_id,
             'selected_activity_type': activity_type_id,
+            'sort': sort,
+            'per_page': per_page,
+            'base_qs': base_qs,
+            'sort_qs': sort_qs,
+            'sortable_columns': [
+                ('title', 'Title'), ('equipment', 'Equipment'),
+                ('activity_type', 'Activity Type'), ('scheduled_start', 'Scheduled Start'),
+                ('status', 'Status'), ('priority', 'Priority'), ('assigned_to', 'Assigned To'),
+            ],
         }
-        
+
         return render(request, 'maintenance/activity_list.html', context)
         
     except Exception as e:
@@ -318,6 +354,15 @@ def activity_list(request):
                 'selected_status': status,
                 'selected_equipment': equipment_id,
                 'selected_activity_type': activity_type_id,
+                'sort': '-scheduled_start',
+                'per_page': 25,
+                'base_qs': '',
+                'sort_qs': '',
+                'sortable_columns': [
+                    ('title', 'Title'), ('equipment', 'Equipment'),
+                    ('activity_type', 'Activity Type'), ('scheduled_start', 'Scheduled Start'),
+                    ('status', 'Status'), ('priority', 'Priority'), ('assigned_to', 'Assigned To'),
+                ],
                 'database_error': True,
                 'error_message': 'Database schema issue detected. Some functionality may be limited.'
             }

--- a/templates/maintenance/activity_list.html
+++ b/templates/maintenance/activity_list.html
@@ -25,42 +25,46 @@
     <div class="row">
         <div class="col-12">
             <div class="card">
-                <div class="card-header">
-                    <div class="row">
-                        <div class="col-md-8">
-                            <h5 class="mb-0">Activity List</h5>
-                        </div>
-                        <div class="col-md-4">
-                            <form method="get" class="d-flex">
-                                <input type="text" name="search" class="form-control me-2" placeholder="Search activities..." value="{{ search_term }}">
-                                <button type="submit" class="btn btn-outline-secondary">
-                                    <i class="fas fa-search"></i>
-                                </button>
-                            </form>
-                        </div>
-                    </div>
+                <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <h5 class="mb-0">Activity List</h5>
+                    <form method="get" class="d-flex align-items-center gap-2 flex-wrap">
+                        <input type="hidden" name="sort" value="{{ sort }}">
+                        <input type="hidden" name="status" value="{{ selected_status|default:'' }}">
+                        <input type="hidden" name="equipment" value="{{ selected_equipment|default:'' }}">
+                        <input type="hidden" name="activity_type" value="{{ selected_activity_type|default:'' }}">
+                        <input type="text" name="search" class="form-control form-control-sm" placeholder="Search activities..." value="{{ search_term }}" style="max-width:220px;">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm"><i class="fas fa-search"></i></button>
+                        <select name="per_page" class="form-select form-select-sm" style="width:auto;" onchange="this.form.submit()">
+                            <option value="25" {% if per_page == 25 %}selected{% endif %}>25 / page</option>
+                            <option value="50" {% if per_page == 50 %}selected{% endif %}>50 / page</option>
+                            <option value="100" {% if per_page == 100 %}selected{% endif %}>100 / page</option>
+                            <option value="200" {% if per_page == 200 %}selected{% endif %}>200 / page</option>
+                        </select>
+                    </form>
                 </div>
                 <div class="card-body">
                     <form id="bulkDeleteForm" method="post" action="{% url 'maintenance:bulk_delete_activities' %}">
                         {% csrf_token %}
                         <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                        <div class="mb-3">
+                        <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
                             <button type="submit" id="bulkDeleteBtn" class="btn btn-danger btn-sm" disabled>
                                 <i class="fas fa-trash"></i> Delete Selected (<span id="bulkSelectedCount">0</span>)
                             </button>
+                            <small class="text-muted"><i class="fas fa-info-circle me-1"></i>Tip: click a checkbox, then <strong>Shift</strong>+click another to select a range.</small>
                         </div>
                     <div class="table-responsive">
                         <table class="table table-hover">
                             <thead>
                                 <tr>
                                     <th style="width:32px;"><input type="checkbox" id="bulkSelectAll" title="Select all on this page"></th>
-                                    <th>Title</th>
-                                    <th>Equipment</th>
-                                    <th>Activity Type</th>
-                                    <th>Scheduled Start</th>
-                                    <th>Status</th>
-                                    <th>Priority</th>
-                                    <th>Assigned To</th>
+                                    {% for key, label in sortable_columns %}
+                                    <th>
+                                        <a href="?{% if sort_qs %}{{ sort_qs }}&{% endif %}sort={% if sort == key %}-{{ key }}{% else %}{{ key }}{% endif %}" class="text-reset text-decoration-none">
+                                            {{ label }}
+                                            {% if sort == key %}<i class="fas fa-sort-up ms-1"></i>{% elif sort == '-'|add:key %}<i class="fas fa-sort-down ms-1"></i>{% else %}<i class="fas fa-sort ms-1 text-muted"></i>{% endif %}
+                                        </a>
+                                    </th>
+                                    {% endfor %}
                                     <th>Actions</th>
                                 </tr>
                             </thead>
@@ -118,25 +122,25 @@
                         <ul class="pagination justify-content-center">
                             {% if page_obj.has_previous %}
                                 <li class="page-item">
-                                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    <a class="page-link" href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ page_obj.previous_page_number }}">Previous</a>
                                 </li>
                             {% endif %}
-                            
+
                             {% for num in page_obj.paginator.page_range %}
                                 {% if page_obj.number == num %}
                                     <li class="page-item active">
                                         <span class="page-link">{{ num }}</span>
                                     </li>
-                                {% else %}
+                                {% elif num > page_obj.number|add:'-5' and num < page_obj.number|add:'5' %}
                                     <li class="page-item">
-                                        <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+                                        <a class="page-link" href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ num }}">{{ num }}</a>
                                     </li>
                                 {% endif %}
                             {% endfor %}
-                            
+
                             {% if page_obj.has_next %}
                                 <li class="page-item">
-                                    <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    <a class="page-link" href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ page_obj.next_page_number }}">Next</a>
                                 </li>
                             {% endif %}
                         </ul>
@@ -171,7 +175,23 @@ document.addEventListener('DOMContentLoaded', function () {
         items().forEach(function (c) { c.checked = selectAll.checked; });
         update();
     });
-    items().forEach(function (c) { c.addEventListener('change', update); });
+
+    // Shift-click range selection: click one checkbox, then Shift+click another
+    // to (de)select everything in between, matching the anchor's new state.
+    var lastIndex = null;
+    items().forEach(function (c) {
+        c.addEventListener('click', function (e) {
+            var all = items();
+            var idx = all.indexOf(c);
+            if (e.shiftKey && lastIndex !== null && lastIndex !== idx) {
+                var start = Math.min(lastIndex, idx);
+                var end = Math.max(lastIndex, idx);
+                for (var i = start; i <= end; i++) { all[i].checked = c.checked; }
+            }
+            lastIndex = idx;
+            update();
+        });
+    });
     if (form) form.addEventListener('submit', function (e) {
         var n = items().filter(function (c) { return c.checked; }).length;
         if (n === 0) { e.preventDefault(); return; }


### PR DESCRIPTION
Makes the activity list easier to work through (esp. cleaning up buggy/legacy activities).

- **Sortable columns** — click a header to sort (title / equipment / activity type / scheduled start / status / priority / assigned to); click again to flip asc/desc, with arrow indicators. Whitelisted \`?sort=\` in the view.
- **Page size** — 25 / 50 / 100 / 200 selector in the header.
- **Shift-click range select** — click one checkbox, **Shift**+click another to (de)select everything between (matches the anchor's checked state). Select-all-on-page unchanged.
- **Pagination & header form** now preserve the active filters, sort, and page size.

Pairs with the bulk-delete perf fix (#153) so large clean-ups are fast.

## Verify (dev)
Activities → All Activities: click headers to sort; change page size; check one row, Shift+click another to grab a range; Delete Selected; paginate — filters/sort persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)