### PR TITLE
feat(email): SMTP relay + password-reset templates + test command

### DIFF
--- a/core/management/commands/send_test_email.py
+++ b/core/management/commands/send_test_email.py
@@ -1,0 +1,36 @@
+"""Send a test email to verify the SMTP configuration / relay is working."""
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Send a test email to confirm email delivery is working."
+
+    def add_arguments(self, parser):
+        parser.add_argument('to', help='Recipient email address.')
+        parser.add_argument('--subject', default='Maintenance Dashboard — test email')
+        parser.add_argument('--message', default='This is a test email from the Maintenance Dashboard. '
+                                                 'If you received it, SMTP delivery is working.')
+
+    def handle(self, *args, **options):
+        to = options['to']
+        self.stdout.write(f"Backend : {settings.EMAIL_BACKEND}")
+        self.stdout.write(f"Host    : {settings.EMAIL_HOST}:{settings.EMAIL_PORT} (TLS={settings.EMAIL_USE_TLS})")
+        self.stdout.write(f"From    : {settings.DEFAULT_FROM_EMAIL}")
+        self.stdout.write(f"To      : {to}")
+        try:
+            sent = send_mail(
+                subject=options['subject'],
+                message=options['message'],
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[to],
+                fail_silently=False,
+            )
+        except Exception as e:
+            raise CommandError(f"Failed to send: {e}")
+        if sent:
+            self.stdout.write(self.style.SUCCESS(f"Sent {sent} message(s) to {to}."))
+        else:
+            self.stdout.write(self.style.WARNING("send_mail returned 0 — nothing sent."))

--- a/maintenance_dashboard/settings.py
+++ b/maintenance_dashboard/settings.py
@@ -489,7 +489,9 @@ EMAIL_PORT = config('EMAIL_PORT', default=587, cast=int)
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
-DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='noreply@maintenance-dashboard.com')
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='no-reply@errorlog.app')
+# Used for error/admin mail; defaults to the same from-address.
+SERVER_EMAIL = config('SERVER_EMAIL', default=DEFAULT_FROM_EMAIL)
 
 # System Monitoring Configuration
 MONITORING_ENABLED = config('MONITORING_ENABLED', default=True, cast=bool)

--- a/portainer-stack-dev.yml
+++ b/portainer-stack-dev.yml
@@ -64,6 +64,18 @@ services:
         reservations:
           memory: 128M
 
+  # Outbound SMTP relay (sends mail directly; set RELAY_HOST to use a smarthost).
+  postfix-relay:
+    image: bytemark/smtp
+    container_name: maintenance_mailer_dev
+    restart: unless-stopped
+    networks:
+      - maintenance_network_dev
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
   web-dev:
     build:
       context: .
@@ -98,6 +110,13 @@ services:
       - ADMIN_EMAIL=admin@dev.maintenance.errorlog.app
       - ADMIN_PASSWORD=DevAdminPassword2024!
       - DOMAIN=dev.maintenance.errorlog.app
+      # Email (SMTP via the postfix-relay sidecar; sends as no-reply@errorlog.app)
+      - EMAIL_BACKEND=${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
+      - EMAIL_HOST=${EMAIL_HOST:-postfix-relay}
+      - EMAIL_PORT=${EMAIL_PORT:-25}
+      - EMAIL_USE_TLS=${EMAIL_USE_TLS:-False}
+      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-no-reply@errorlog.app}
+      - SERVER_EMAIL=${SERVER_EMAIL:-no-reply@errorlog.app}
       # Development Security Settings
       - SECURE_SSL_REDIRECT=False
       - SESSION_COOKIE_SECURE=False

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -50,6 +50,18 @@ services:
         reservations:
           memory: 128M
 
+  # Outbound SMTP relay (sends mail directly; set RELAY_HOST to use a smarthost).
+  postfix-relay:
+    image: bytemark/smtp
+    container_name: maintenance_mailer_prod
+    restart: unless-stopped
+    networks:
+      - maintenance_network
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
   web:
     build: 
       context: .
@@ -84,6 +96,13 @@ services:
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@maintenance.errorlog.app}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-SecureAdminPassword2024!}
       - DOMAIN=${DOMAIN:-errorlog.app}
+      # Email (SMTP via the postfix-relay sidecar; sends as no-reply@errorlog.app)
+      - EMAIL_BACKEND=${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
+      - EMAIL_HOST=${EMAIL_HOST:-postfix-relay}
+      - EMAIL_PORT=${EMAIL_PORT:-25}
+      - EMAIL_USE_TLS=${EMAIL_USE_TLS:-False}
+      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-no-reply@errorlog.app}
+      - SERVER_EMAIL=${SERVER_EMAIL:-no-reply@errorlog.app}
       # Security Settings
       - SECURE_SSL_REDIRECT=True
       - SESSION_COOKIE_SECURE=True

--- a/templates/registration/_auth_base.html
+++ b/templates/registration/_auth_base.html
@@ -1,0 +1,53 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Maintenance Dashboard{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        body { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); min-height: 100vh;
+            display: flex; align-items: center; justify-content: center;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; }
+        .login-container { max-width: 420px; width: 100%; padding: 20px; }
+        .card { border: none; border-radius: 15px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+            backdrop-filter: blur(10px); background: rgba(255,255,255,0.95); }
+        .card-body { padding: 40px; }
+        .login-title { text-align: center; color: #333; margin-bottom: 24px; font-weight: 600; }
+        .login-icon { text-align: center; margin-bottom: 16px; }
+        .login-icon i { font-size: 3rem; color: #667eea; }
+        .btn-login { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border: none;
+            border-radius: 8px; padding: 12px; font-weight: 600; text-transform: uppercase;
+            letter-spacing: 0.5px; transition: all 0.3s ease; color: #fff; }
+        .btn-login:hover { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(102,126,234,0.4); color:#fff; }
+        .form-control { border-radius: 8px; border: 2px solid #e9ecef; padding: 12px 15px; }
+        .form-control:focus { border-color: #667eea; box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25); }
+        .form-group label { font-weight: 600; color: #555; margin-bottom: 8px; }
+        .alert { border-radius: 8px; border: none; }
+        .auth-links { text-align: center; margin-top: 20px; }
+        .auth-links a { color: #667eea; text-decoration: none; font-size: 0.9rem; }
+        .auth-links a:hover { text-decoration: underline; }
+        .text-muted-sm { color: #6c757d; font-size: 0.92rem; }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="card">
+            <div class="card-body">
+                <div class="login-icon"><i class="fas fa-tools"></i></div>
+                <h2 class="login-title">{% block heading %}Maintenance Dashboard{% endblock %}</h2>
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ message.tags }}" role="alert">{{ message }}</div>
+                    {% endfor %}
+                {% endif %}
+                {% block content %}{% endblock %}
+            </div>
+        </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,0 +1,7 @@
+{% extends 'registration/_auth_base.html' %}
+{% block title %}Password reset complete - Maintenance Dashboard{% endblock %}
+{% block heading %}Password updated{% endblock %}
+{% block content %}
+    <p class="text-muted-sm text-center">Your password has been set. You can now sign in with your new password.</p>
+    <a href="{% url 'login' %}" class="btn btn-login btn-block"><i class="fas fa-sign-in-alt me-2"></i>Go to login</a>
+{% endblock %}

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,0 +1,25 @@
+{% extends 'registration/_auth_base.html' %}
+{% load widget_tweaks %}
+{% block title %}Set a new password - Maintenance Dashboard{% endblock %}
+{% block heading %}Set a new password{% endblock %}
+{% block content %}
+    {% if validlink %}
+        <form method="post">
+            {% csrf_token %}
+            <div class="form-group">
+                <label for="{{ form.new_password1.id_for_label }}"><i class="fas fa-lock me-2"></i>New password</label>
+                {{ form.new_password1|add_class:"form-control" }}
+                {% if form.new_password1.errors %}<div class="text-danger small mt-1">{{ form.new_password1.errors|striptags }}</div>{% endif %}
+            </div>
+            <div class="form-group">
+                <label for="{{ form.new_password2.id_for_label }}"><i class="fas fa-lock me-2"></i>Confirm new password</label>
+                {{ form.new_password2|add_class:"form-control" }}
+                {% if form.new_password2.errors %}<div class="text-danger small mt-1">{{ form.new_password2.errors|striptags }}</div>{% endif %}
+            </div>
+            <button type="submit" class="btn btn-login btn-block"><i class="fas fa-check me-2"></i>Change password</button>
+        </form>
+    {% else %}
+        <div class="alert alert-danger">This password reset link is invalid or has expired. Please request a new one.</div>
+        <div class="auth-links"><a href="{% url 'password_reset' %}">Request a new reset link</a></div>
+    {% endif %}
+{% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,0 +1,10 @@
+{% extends 'registration/_auth_base.html' %}
+{% block title %}Check your email - Maintenance Dashboard{% endblock %}
+{% block heading %}Check your email{% endblock %}
+{% block content %}
+    <p class="text-muted-sm text-center">
+        If an account exists for that email address, we've sent a message with instructions to reset your password.
+        It should arrive shortly — check your spam folder if you don't see it.
+    </p>
+    <div class="auth-links"><a href="{% url 'login' %}"><i class="fas fa-arrow-left me-1"></i>Back to login</a></div>
+{% endblock %}

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,0 +1,13 @@
+{% autoescape off %}
+Hi {{ user.get_username }},
+
+You're receiving this email because you (or someone else) requested a password reset for your Maintenance Dashboard account.
+
+Click the link below to choose a new password:
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If you didn't request this, you can safely ignore this email — your password won't change.
+
+— Maintenance Dashboard
+{% endautoescape %}

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,0 +1,17 @@
+{% extends 'registration/_auth_base.html' %}
+{% load widget_tweaks %}
+{% block title %}Reset Password - Maintenance Dashboard{% endblock %}
+{% block heading %}Reset your password{% endblock %}
+{% block content %}
+    <p class="text-muted-sm text-center mb-4">Enter the email on your account and we'll send you a link to set a new password.</p>
+    <form method="post">
+        {% csrf_token %}
+        <div class="form-group">
+            <label for="{{ form.email.id_for_label }}"><i class="fas fa-envelope me-2"></i>Email</label>
+            {{ form.email|add_class:"form-control" }}
+            {% if form.email.errors %}<div class="text-danger small mt-1">{{ form.email.errors|striptags }}</div>{% endif %}
+        </div>
+        <button type="submit" class="btn btn-login btn-block"><i class="fas fa-paper-plane me-2"></i>Send reset link</button>
+    </form>
+    <div class="auth-links"><a href="{% url 'login' %}"><i class="fas fa-arrow-left me-1"></i>Back to login</a></div>
+{% endblock %}

--- a/templates/registration/password_reset_subject.txt
+++ b/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Reset your Maintenance Dashboard password


### PR DESCRIPTION
End-to-end email for the dashboard (GH #80), using a `bytemark/smtp` relay sidecar like your n8n setup, sending as **no-reply@errorlog.app**.

## What's included
- **Settings**: `DEFAULT_FROM_EMAIL` → `no-reply@errorlog.app`, added `SERVER_EMAIL`. (EMAIL_* were already env-driven.)
- **Stacks (prod + dev)**: added a `postfix-relay` (`bytemark/smtp`) service on the internal network and pointed `web` at it — `EMAIL_BACKEND=smtp`, `EMAIL_HOST=postfix-relay`, `EMAIL_PORT=25`, `EMAIL_USE_TLS=False`, from `no-reply@errorlog.app`. All overridable via env (e.g. set `RELAY_HOST` on the relay to use a smarthost, or point `EMAIL_HOST` at your existing mailer).
- **Password reset**: the reset URLs + login "Forgot password?" link were already wired but the **templates didn't exist** (would 500). Added form/done/confirm/complete + email body + subject via a shared `registration/_auth_base.html`.
- **`send_test_email <to>`** management command to verify delivery.
- The existing reminder tasks (`send_maintenance_reminders`, `send_event_reminders`) now actually deliver once the relay is up.

## Deploy / verify
After the relay deploys, test from the web container:
```
python manage.py send_test_email you@example.com
```
Then try the "Forgot password?" flow. Deliverability relies on errorlog.app's existing SPF/DKIM (already set up for your other service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)