### PR TITLE
fix(rbac): close read-only access gaps (calendar, branding, settings, issue UI)

### DIFF
--- a/core/views/branding_css.py
+++ b/core/views/branding_css.py
@@ -41,9 +41,10 @@ import redis
 from django_celery_beat.models import PeriodicTask
 from django.utils import timezone
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
+from core.rbac import permission_required
 
 
-@login_required
+@permission_required('administration.write')
 def branding_settings(request):
     """Branding settings management page"""
     # Check if branding tables exist before trying to access them
@@ -185,7 +186,7 @@ def css_customization_list(request):
         return redirect('core:branding_settings')
 
 
-@login_required
+@permission_required('administration.write')
 def css_customization_create(request):
     """Create a new CSS customization"""
     # Check if CSS customization table exists
@@ -228,7 +229,7 @@ def css_customization_create(request):
         return redirect('core:branding_settings')
 
 
-@login_required
+@permission_required('administration.write')
 def css_customization_edit(request, pk):
     """Edit an existing CSS customization"""
     # Check if CSS customization table exists
@@ -276,7 +277,7 @@ def css_customization_edit(request, pk):
         return redirect('core:branding_settings')
 
 
-@login_required
+@permission_required('administration.write')
 def css_customization_delete(request, pk):
     """Delete a CSS customization"""
     # Check if CSS customization table exists
@@ -357,7 +358,7 @@ def css_preview(request):
         return redirect('core:branding_settings')
 
 
-@login_required
+@permission_required('administration.write')
 def css_toggle(request, pk):
     """Toggle CSS customization active status"""
     # Check if CSS customization table exists

--- a/events/views.py
+++ b/events/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
+from core.rbac import permission_required
 from django.contrib import messages
 from django.utils import timezone
 from django.db.models import Q
@@ -455,7 +456,7 @@ def event_list(request):
     return render(request, 'events/event_list.html', context)
 
 
-@login_required
+@permission_required('events.write')
 def add_event(request):
     """Redirect to maintenance activity creation - calendar events are now only created from maintenance activities."""
     messages.info(request, 'Calendar events are automatically created from maintenance activities. Please create a maintenance activity instead.')
@@ -480,7 +481,7 @@ def event_detail(request, event_id):
     return redirect('events:calendar_view')
 
 
-@login_required
+@permission_required('events.write')
 def edit_event(request, event_id):
     """Redirect to maintenance activity edit - calendar events are now only updated via maintenance activities."""
     event = get_object_or_404(CalendarEvent, id=event_id)
@@ -495,7 +496,7 @@ def edit_event(request, event_id):
     return redirect('events:calendar_view')
 
 
-@login_required
+@permission_required('events.write')
 def complete_event(request, event_id):
     """Mark an event as complete."""
     if request.method == 'POST':
@@ -511,7 +512,7 @@ def complete_event(request, event_id):
     return JsonResponse({'error': 'Method not allowed'}, status=405)
 
 
-@login_required
+@permission_required('events.write')
 def delete_event(request, event_id):
     """Redirect to maintenance activity delete - calendar events are now only deleted via maintenance activities."""
     event = get_object_or_404(CalendarEvent, id=event_id)
@@ -534,7 +535,7 @@ def delete_event(request, event_id):
     return render(request, 'events/delete_event.html', context)
 
 
-@login_required
+@permission_required('events.write')
 def delete_event_ajax(request, event_id):
     """Delete a calendar event via AJAX."""
     if request.method == 'POST':

--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -1227,7 +1227,7 @@ def get_activity_details(request, activity_id):
         return JsonResponse({'error': 'Failed to get activity details'}, status=500)
 
 
-@login_required
+@permission_required('maintenance.create')
 @require_http_methods(["POST"])
 def create_activity_api(request):
     """API endpoint for creating maintenance activities via AJAX."""

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load rbac_tags %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1093,6 +1094,7 @@
                      <i class="fas fa-map me-1"></i> {{ navigation_map_label }}
                  </a>
             </li>
+            {% if user|has_permission:'administration.read' %}
             <li class="nav-item dropdown">
                                  <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
                      <i class="fas fa-cog me-1"></i> {{ navigation_settings_label }}
@@ -1120,6 +1122,7 @@
                      </a>
                  </div>
             </li>
+            {% endif %}
             {% if user.is_superuser %}
             <li class="nav-item">
                                  <a class="nav-link {% if request.resolver_match.url_name == 'debug' %}active{% endif %}" 

--- a/templates/equipment/equipment_detail.html
+++ b/templates/equipment/equipment_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load tz %}
+{% load rbac_tags %}
 
 {% block title %}{{ equipment.name }} - Equipment Details{% endblock %}
 
@@ -23,9 +24,11 @@
                     <p class="text-muted mb-0">{{ equipment.category.name|default:"No Category" }} • {{ equipment.location.name|default:"No Location" }}</p>
                 </div>
                 <div>
+                    {% if user|has_permission:'issues.create' %}
                     <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#logIssueModal">
                         <i class="fas fa-exclamation-triangle me-1"></i> Log Issue
                     </button>
+                    {% endif %}
                     <a href="{% url 'equipment:equipment_kpi_tracker' equipment.id %}" class="btn btn-info">
                         <i class="fas fa-chart-line me-1"></i> KPI Tracker
                     </a>
@@ -762,9 +765,11 @@
                     <div class="tab-pane fade" id="issues" role="tabpanel">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h6 class="mb-0">Equipment Issues</h6>
+                            {% if user|has_permission:'issues.create' %}
                             <button type="button" class="btn btn-sm btn-warning" data-toggle="modal" data-target="#logIssueModal">
                                 <i class="fas fa-exclamation-triangle me-1"></i> Log New Issue
                             </button>
+                            {% endif %}
                         </div>
                         
                         <!-- Issue Summary Cards -->
@@ -899,9 +904,11 @@
                             <div class="text-center py-4">
                                 <i class="fas fa-exclamation-triangle fa-3x text-muted mb-3"></i>
                                 <p class="text-muted">No issues logged for this equipment</p>
+                                {% if user|has_permission:'issues.create' %}
                                 <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#logIssueModal">
                                     <i class="fas fa-exclamation-triangle me-1"></i> Log First Issue
                                 </button>
+                                {% endif %}
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
Read-only (viewer) users could access/modify things they shouldn't — the deferred "everything tier" of the RBAC hardening.

## Backend (the real holes)
- **Calendar create**: `create_activity_api` (`/maintenance/api/activities/create/`, used by the calendar's create modal) was login-only → now `maintenance.create`. This is why viewers could "create calendar events".
- **Calendar modify/delete**: `events` add/edit/complete/delete/delete_ajax → `events.write`.
- **Branding**: `branding_settings` + CSS create/edit/delete/toggle → `administration.write`.

## UI (defense-in-depth + the visible complaints)
- **Settings** nav dropdown hidden unless `administration.read` (was always shown).
- **Log Issue** buttons on equipment detail (header, tab, empty-state) hidden unless `issues.create` (the "can't add but sees the button" issue).

Viewers lack these perms; **manager/admin** roles keep them; **superusers** bypass.

## Verify (dev)
As a `viewer`: no Settings menu, no Log Issue buttons, and calendar create / branding edits are blocked (403/redirect). As admin: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)