### PR TITLE
fix: gate document upload (RBAC) + roles 'Edit' 404

### DIFF
--- a/equipment/views.py
+++ b/equipment/views.py
@@ -919,7 +919,7 @@ def equipment_documents(request, equipment_id):
     return render(request, 'equipment/equipment_documents.html', context)
 
 
-@login_required
+@permission_required('equipment.edit')
 def add_document(request, equipment_id):
     """Add document to equipment."""
     equipment = get_object_or_404(Equipment, id=equipment_id)

--- a/templates/core/roles_permissions_management.html
+++ b/templates/core/roles_permissions_management.html
@@ -539,7 +539,7 @@ $(document).ready(function() {
         
         // Load role data
         $.ajax({
-            url: '/core/api/roles/' + roleId + '/',
+            url: '/api/roles/' + roleId + '/',
             method: 'GET',
             success: function(data) {
                 $('#editRoleId').val(data.id);
@@ -590,7 +590,7 @@ $(document).ready(function() {
         };
         
         $.ajax({
-            url: '/core/api/roles/' + roleId + '/',
+            url: '/api/roles/' + roleId + '/',
             method: 'PUT',
             headers: {
                 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val(),
@@ -622,7 +622,7 @@ $(document).ready(function() {
         const roleId = $('#deleteRoleId').val();
         
         $.ajax({
-            url: '/core/api/roles/' + roleId + '/',
+            url: '/api/roles/' + roleId + '/',
             method: 'DELETE',
             headers: {
                 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val()

--- a/templates/equipment/equipment_detail.html
+++ b/templates/equipment/equipment_detail.html
@@ -496,9 +496,11 @@
                     <div class="tab-pane fade" id="documents" role="tabpanel">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h6 class="mb-0">Equipment Documents</h6>
+                            {% if user|has_permission:'equipment.edit' %}
                             <a href="{% url 'equipment:add_document' equipment.id %}" class="btn btn-sm btn-primary">
                                 <i class="fas fa-upload me-1"></i> Upload Document
                             </a>
+                            {% endif %}
                         </div>
                         
                         {% if documents %}
@@ -550,9 +552,11 @@
                             <div class="text-center py-4">
                                 <i class="fas fa-file-alt fa-3x text-muted mb-3"></i>
                                 <p class="text-muted">No documents uploaded</p>
+                                {% if user|has_permission:'equipment.edit' %}
                                 <a href="{% url 'equipment:add_document' equipment.id %}" class="btn btn-primary">
                                     <i class="fas fa-upload me-1"></i> Upload First Document
                                 </a>
+                                {% endif %}
                             </div>
                         {% endif %}
                     </div>

--- a/templates/equipment/equipment_documents.html
+++ b/templates/equipment/equipment_documents.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load rbac_tags %}
 
 {% block title %}Documents - {{ equipment.name }}{% endblock %}
 
@@ -22,9 +23,11 @@
                     <p class="text-muted mb-0">Documents and reports for {{ equipment.name }}</p>
                 </div>
                 <div>
+                    {% if user|has_permission:'equipment.edit' %}
                     <a href="{% url 'equipment:add_document' equipment.id %}" class="btn btn-primary">
                         <i class="fas fa-upload me-1"></i> Upload Document
                     </a>
+                    {% endif %}
                     <a href="{% url 'equipment:equipment_detail' equipment.id %}" class="btn btn-outline-secondary">
                         <i class="fas fa-arrow-left me-1"></i> Back to Equipment
                     </a>
@@ -78,9 +81,11 @@
                     <div class="text-center py-4">
                         <i class="fas fa-file-alt fa-3x text-muted mb-3"></i>
                         <p class="text-muted">No equipment documents available</p>
+                        {% if user|has_permission:'equipment.edit' %}
                         <a href="{% url 'equipment:add_document' equipment.id %}" class="btn btn-primary">
                             <i class="fas fa-upload me-1"></i> Upload First Document
                         </a>
+                        {% endif %}
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
Two fixes.

## Read-only could upload documents
`add_document` was login-only → now requires `equipment.edit`. Upload buttons on the equipment-detail Documents tab and the documents page are hidden unless the user has `equipment.edit`. (Viewers lack it; technician/manager/admin keep it.)

## "Edit role" doesn't load (404)
Roles & Permissions → Edit fetched `/core/api/roles/<id>/`, but `core.urls` is mounted at **root**, so it 404'd to an HTML page → *"Error loading role data"*. Fixed the 3 hardcoded URLs to `/api/roles/<id>/` (`core:role_detail_api`). Same `/core/` prefix class as the earlier debug DB-stats fix.

## Verify (dev)
- As a viewer: no Upload Document buttons; POST to add_document is blocked.
- Roles & Permissions → click the Edit (pencil) on a role → the role loads into the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)