### PR TITLE
fix: remaining /core/ prefixes + Email in System Health

### DIFF
--- a/core/views/helpers.py
+++ b/core/views/helpers.py
@@ -236,35 +236,57 @@ def get_comprehensive_system_health():
     celery_beat_health = check_celery_beat_health()
     health_data['components']['celery_beat'] = celery_beat_health
     
+    # Email / SMTP health
+    email_health = check_email_health()
+    health_data['components']['email'] = email_health
+
     # System metrics
     try:
         system_metrics = get_system_metrics()
         health_data['components']['system'] = system_metrics
     except Exception as e:
         health_data['components']['system'] = {'error': str(e)}
-    
+
     # Determine overall status
     if db_health.get('status') == 'unhealthy':
         health_data['overall_status'] = 'critical'
-    elif cache_health.get('status') == 'unhealthy':
+    elif (cache_health.get('status') == 'unhealthy'
+          or celery_health.get('status') == 'unhealthy'
+          or celery_beat_health.get('status') == 'unhealthy'
+          or email_health.get('status') == 'unhealthy'):
         health_data['overall_status'] = 'warning'
-    elif celery_health.get('status') == 'unhealthy' or celery_beat_health.get('status') == 'unhealthy':
-        health_data['overall_status'] = 'warning'
-    
+
     return health_data
 
 
-def check_celery_worker_health():
-    """Check Celery worker health by running inspect ping."""
+def check_email_health():
+    """Check email config: SMTP connectivity, or note a non-SMTP backend."""
+    from django.conf import settings
+    from django.core.mail import get_connection
+    backend = getattr(settings, 'EMAIL_BACKEND', '') or ''
+    short = backend.rsplit('.', 1)[-1] if backend else 'unknown'
+    if 'smtp' not in backend.lower():
+        # console/locmem/filebased backends don't send real mail — not an error.
+        return {'status': 'healthy', 'message': f'{short} (no SMTP relay configured)'}
+    host = getattr(settings, 'EMAIL_HOST', '')
+    port = getattr(settings, 'EMAIL_PORT', '')
     try:
-        import subprocess
-        result = subprocess.run([
-            'celery', '-A', 'maintenance_dashboard', 'inspect', 'ping'
-        ], capture_output=True, text=True, timeout=10)
-        if result.returncode == 0 and 'pong' in result.stdout:
-            return {'status': 'healthy', 'output': result.stdout}
-        else:
-            return {'status': 'unhealthy', 'output': result.stdout + result.stderr}
+        conn = get_connection(timeout=5)
+        conn.open()
+        conn.close()
+        return {'status': 'healthy', 'message': f'SMTP {host}:{port} reachable'}
+    except Exception as e:
+        return {'status': 'unhealthy', 'error': f'{host}:{port} — {e}'}
+
+
+def check_celery_worker_health():
+    """Check Celery worker health via a broker ping (no subprocess/celery binary)."""
+    try:
+        from maintenance_dashboard.celery import app
+        replies = app.control.inspect(timeout=3).ping()
+        if replies:
+            return {'status': 'healthy', 'message': f"{len(replies)} worker(s) responding"}
+        return {'status': 'unhealthy', 'message': 'No workers responded to ping'}
     except Exception as e:
         return {'status': 'unhealthy', 'error': str(e)}
 

--- a/templates/core/locations_settings.html
+++ b/templates/core/locations_settings.html
@@ -1091,7 +1091,7 @@ $(document).ready(function() {
         };
         
         $.ajax({
-            url: '/core/api/locations/' + id + '/',
+            url: '/api/locations/' + id + '/',
             method: 'PUT',
             headers: {
                 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val(),
@@ -1151,7 +1151,7 @@ $(document).ready(function() {
         };
         
         $.ajax({
-            url: '/core/api/locations/' + locationId + '/',
+            url: '/api/locations/' + locationId + '/',
             method: 'PUT',
             headers: {
                 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val(),

--- a/templates/core/version.html
+++ b/templates/core/version.html
@@ -90,7 +90,7 @@
                                 <a href="/version/" class="btn btn-outline-primary" target="_blank">
                                     <i class="fas fa-code me-1"></i>View JSON
                                 </a>
-                                <a href="/core/version/" class="btn btn-outline-secondary" target="_blank">
+                                <a href="{% url 'core:version' %}" class="btn btn-outline-secondary" target="_blank">
                                     <i class="fas fa-code me-1"></i>Core Version
                                 </a>
                                 <button class="btn btn-outline-info" onclick="refreshVersion()">


### PR DESCRIPTION
## /core/ prefix scan
Found and fixed the remaining hardcoded `/core/...` paths (core is mounted at root, so they 404 to an HTML page):
- **Locations settings**: edit/delete fetched `/core/api/locations/<id>/` → `/api/locations/<id>/`.
- **Version page**: "Core Version" link `/core/version/` → `{% url 'core:version' %}`.

Scanned all templates + static JS — no `/core/` paths remain.

## System Health
- **New Email component** — for the `smtp` backend it opens a connection to the relay (`EMAIL_HOST:EMAIL_PORT`) and reports reachable/unhealthy; non-SMTP backends (console etc.) report healthy with a "no SMTP relay" note. Folded into overall status.
- **Celery worker** check now pings workers **via the broker** (`app.control.inspect().ping()`) instead of shelling out to the `celery` binary, which was unreliable in the container (the "always offline" symptom). If a worker is actually running it'll now show healthy; if none is running it correctly shows unhealthy.

## Verify (dev/prod)
Debug → System Health shows an **Email** row; on prod (SMTP relay) it reads "reachable". Locations edit/delete and the version "Core Version" link work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)