### PR TITLE
style(settings): consolidate Settings menu into a sectioned hub

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1100,25 +1100,15 @@
                      <i class="fas fa-cog me-1"></i> {{ navigation_settings_label }}
                  </a>
                                  <div class="dropdown-menu">
-                     <a class="dropdown-item" href="{% url 'core:branding_settings' %}">
-                         <i class="fas fa-palette me-1"></i> Branding
+                     <a class="dropdown-item" href="{% url 'core:settings' %}">
+                         <i class="fas fa-sliders-h me-1"></i> All Settings
                      </a>
-                     <a class="dropdown-item" href="{% url 'core:dashboard_settings' %}">
-                         <i class="fas fa-tachometer-alt me-1"></i> Dashboard Settings
-                     </a>
-                     <a class="dropdown-item" href="{% url 'equipment:field_configuration_settings' %}">
-                         <i class="fas fa-list-alt me-1"></i> Equipment Field Configuration
-                     </a>
-                     <a class="dropdown-item" href="{% url 'core:settings' %}">General Settings</a>
-                     <a class="dropdown-item" href="{% url 'core:locations_settings' %}">Locations</a>
-                     <a class="dropdown-item" href="{% url 'core:customers_settings' %}">Customers</a>
-                     <a class="dropdown-item" href="{% url 'core:equipment_items_settings' %}">Equipment Items</a>
                      <div class="dropdown-divider"></div>
-                     <a class="dropdown-item" href="{% url 'core:version_html' %}">
-                         <i class="fas fa-code-branch me-1"></i> Version Info
+                     <a class="dropdown-item" href="{% url 'core:user_management' %}">
+                         <i class="fas fa-users me-1"></i> User Management
                      </a>
-                     <a class="dropdown-item" href="{% url 'core:version_form' %}">
-                         <i class="fas fa-edit me-1"></i> Set Version
+                     <a class="dropdown-item" href="{% url 'core:roles_permissions_management' %}">
+                         <i class="fas fa-user-shield me-1"></i> Roles &amp; Permissions
                      </a>
                  </div>
             </li>

--- a/templates/core/settings.html
+++ b/templates/core/settings.html
@@ -268,74 +268,103 @@
         <p class="text-muted mb-0">Manage your preferences and system settings</p>
     </div>
 
-    <!-- Quick Actions -->
+    <!-- Appearance -->
+    <h5 class="mt-4 mb-3" style="font-size:0.9rem; text-transform:uppercase; letter-spacing:.05em; color:#a0aec0;">Appearance</h5>
+    <div class="quick-actions">
+        <a href="{% url 'core:branding_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-palette"></i></div>
+            <div class="quick-action-title">Branding</div>
+            <div class="quick-action-desc">Logo, colors, names, and navigation labels</div>
+        </a>
+        <a href="{% url 'core:dashboard_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-tachometer-alt"></i></div>
+            <div class="quick-action-title">Dashboard Settings</div>
+            <div class="quick-action-desc">Configure the overview dashboard</div>
+        </a>
+    </div>
+
+    <!-- Data -->
+    <h5 class="mt-4 mb-3" style="font-size:0.9rem; text-transform:uppercase; letter-spacing:.05em; color:#a0aec0;">Data</h5>
+    <div class="quick-actions">
+        <a href="{% url 'core:locations_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-map-marker-alt"></i></div>
+            <div class="quick-action-title">Locations</div>
+            <div class="quick-action-desc">Manage sites and equipment locations</div>
+        </a>
+        <a href="{% url 'core:customers_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-user-tie"></i></div>
+            <div class="quick-action-title">Customers</div>
+            <div class="quick-action-desc">Manage customers</div>
+        </a>
+        <a href="{% url 'core:equipment_items_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-tools"></i></div>
+            <div class="quick-action-title">Equipment Items</div>
+            <div class="quick-action-desc">Manage equipment and categories</div>
+        </a>
+        <a href="{% url 'equipment:field_configuration_settings' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-list-alt"></i></div>
+            <div class="quick-action-title">Equipment Field Configuration</div>
+            <div class="quick-action-desc">Configure custom equipment fields</div>
+        </a>
+    </div>
+
+    <!-- Users & Access -->
+    <h5 class="mt-4 mb-3" style="font-size:0.9rem; text-transform:uppercase; letter-spacing:.05em; color:#a0aec0;">Users &amp; Access</h5>
+    <div class="quick-actions">
+        <a href="{% url 'core:user_management' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-users"></i></div>
+            <div class="quick-action-title">User Management</div>
+            <div class="quick-action-desc">Manage user accounts</div>
+        </a>
+        <a href="{% url 'core:roles_permissions_management' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-user-shield"></i></div>
+            <div class="quick-action-title">Roles &amp; Permissions</div>
+            <div class="quick-action-desc">Manage roles and what they can access</div>
+        </a>
+    </div>
+
+    <!-- System -->
+    <h5 class="mt-4 mb-3" style="font-size:0.9rem; text-transform:uppercase; letter-spacing:.05em; color:#a0aec0;">System</h5>
     <div class="quick-actions">
         {% if user.is_superuser %}
         <a href="{% url 'core:debug' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-bug"></i>
-            </div>
+            <div class="quick-action-icon"><i class="fas fa-bug"></i></div>
             <div class="quick-action-title">Debug & Diagnostics</div>
             <div class="quick-action-desc">System health monitoring and diagnostic tools</div>
         </a>
         {% endif %}
-        
-        <a href="{% url 'core:locations_settings' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-map-marker-alt"></i>
-            </div>
-            <div class="quick-action-title">Locations</div>
-            <div class="quick-action-desc">Manage sites and equipment locations</div>
-        </a>
-        
-        <a href="{% url 'core:equipment_items_settings' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-tools"></i>
-            </div>
-            <div class="quick-action-title">Equipment Items</div>
-            <div class="quick-action-desc">Manage equipment and categories</div>
-        </a>
-        
-        <a href="{% url 'core:user_management' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-users"></i>
-            </div>
-            <div class="quick-action-title">User Management</div>
-            <div class="quick-action-desc">Manage user accounts and permissions</div>
-        </a>
-        
         <a href="{% url 'admin:index' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-database"></i>
-            </div>
+            <div class="quick-action-icon"><i class="fas fa-database"></i></div>
             <div class="quick-action-title">Database Settings</div>
             <div class="quick-action-desc">View and update all database entries</div>
         </a>
         <a href="{% url 'core:api_explorer' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-sitemap"></i>
-            </div>
+            <div class="quick-action-icon"><i class="fas fa-sitemap"></i></div>
             <div class="quick-action-title">API Explorer</div>
             <div class="quick-action-desc">Tree view of all data + API docs</div>
         </a>
-        
         <a href="{% url 'core:webhook_settings' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-sync-alt"></i>
-            </div>
+            <div class="quick-action-icon"><i class="fas fa-sync-alt"></i></div>
             <div class="quick-action-title">Portainer Integration</div>
             <div class="quick-action-desc">Configure Portainer connection and updates</div>
         </a>
-        
         {% if docker_logs_enabled and not docker_logs_debug_only %}
         <a href="{% url 'core:docker_logs' %}" class="quick-action-card text-decoration-none">
-            <div class="quick-action-icon">
-                <i class="fas fa-terminal"></i>
-            </div>
+            <div class="quick-action-icon"><i class="fas fa-terminal"></i></div>
             <div class="quick-action-title">Docker Logs</div>
-            <div class="quick-action-desc">View real-time container logs and diagnose issues</div>
+            <div class="quick-action-desc">View real-time container logs</div>
         </a>
         {% endif %}
+        <a href="{% url 'core:version_html' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-code-branch"></i></div>
+            <div class="quick-action-title">Version Info</div>
+            <div class="quick-action-desc">Build/version details</div>
+        </a>
+        <a href="{% url 'core:version_form' %}" class="quick-action-card text-decoration-none">
+            <div class="quick-action-icon"><i class="fas fa-edit"></i></div>
+            <div class="quick-action-title">Set Version</div>
+            <div class="quick-action-desc">Update the displayed version</div>
+        </a>
     </div>
 
     <!-- User Preferences -->


### PR DESCRIPTION
The Settings dropdown (9 overlapping items) and the General Settings page diverged. Consolidated:

## Dropdown → 3 items
**All Settings** (the hub) · **User Management** · **Roles & Permissions**. Everything else now lives on the hub page.

## General Settings = the complete hub, sectioned
- **Appearance**: Branding, Dashboard Settings
- **Data**: Locations, Customers, Equipment Items, Equipment Field Configuration
- **Users & Access**: User Management, Roles & Permissions
- **System**: Debug (superuser), Database, API Explorer, Portainer, Docker Logs, Version Info, Set Version

Adds the items that were previously dropdown-only (Branding, Dashboard Settings, Field Config, Customers, Version) so the page is the single source of truth. User Preferences + diagnostics below are unchanged.

## Verify (dev)
Settings menu is now short; General Settings shows all areas grouped into sections; every card links correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)