### PR TITLE
refactor(celery): deterministic broker + accurate beat health

### DIFF
--- a/core/views/helpers.py
+++ b/core/views/helpers.py
@@ -296,21 +296,24 @@ def check_celery_beat_health():
     try:
         from django_celery_beat.models import PeriodicTask
         from django.utils import timezone
+        from django.conf import settings as s
         enabled_tasks = PeriodicTask.objects.filter(enabled=True)
         if not enabled_tasks.exists():
             return {'status': 'warning', 'message': 'No periodic tasks enabled'}
-        recent = None
-        for task in enabled_tasks:
-            if task.last_run_at and (recent is None or task.last_run_at > recent):
-                recent = task.last_run_at
+        # Allow up to ~2x the most-frequent scheduled interval before warning —
+        # the old fixed 10-min threshold false-warned because the most frequent
+        # task only runs every couple of hours.
+        intervals = [v.get('schedule') for v in (getattr(s, 'CELERY_BEAT_SCHEDULE', {}) or {}).values()
+                     if isinstance(v.get('schedule'), (int, float))]
+        threshold = (min(intervals) if intervals else 3600) * 2 + 300
+        recent = max((t.last_run_at for t in enabled_tasks if t.last_run_at), default=None)
         if recent:
             seconds_since = (timezone.now() - recent).total_seconds()
-            if seconds_since < 600:
-                return {'status': 'healthy', 'message': f'Recent heartbeat ({int(seconds_since)}s ago)'}
-            else:
-                return {'status': 'warning', 'message': f'No recent heartbeat (last was {int(seconds_since//60)} min ago)'}
-        else:
-            return {'status': 'warning', 'message': 'No periodic tasks have ever run'}
+            if seconds_since <= threshold:
+                return {'status': 'healthy', 'message': f'Last run {int(seconds_since // 60)} min ago'}
+            return {'status': 'warning',
+                    'message': f'No run in {int(seconds_since // 60)} min (expected within {int(threshold // 60)})'}
+        return {'status': 'warning', 'message': 'No periodic tasks have run yet'}
     except Exception as e:
         return {'status': 'unhealthy', 'error': str(e)}
 

--- a/maintenance_dashboard/celery.py
+++ b/maintenance_dashboard/celery.py
@@ -28,7 +28,6 @@ app.conf.worker_send_task_events = True
 app.conf.task_send_sent_event = True
 # Disable superuser privileges - workers should not run as root.
 # os.geteuid only exists on Unix; guard so imports don't crash on Windows dev.
-import os
 if hasattr(os, 'geteuid') and os.geteuid() == 0:
     logging.warning("Celery worker is running as root. This is not recommended for security.")
     # Try to switch to non-root user if available
@@ -44,44 +43,12 @@ if hasattr(os, 'geteuid') and os.geteuid() == 0:
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()
 
-# Configure Celery to handle Redis connection failures gracefully
-def configure_celery_broker():
-    """Configure Celery broker with fallback options."""
-    broker_url = getattr(settings, 'CELERY_BROKER_URL', None)
-    if not broker_url:
-        # Build Redis URL from settings
-        redis_url = getattr(settings, 'REDIS_URL', 'redis://redis:6379')
-        broker_url = f'{redis_url}/0'
-    
-    # If Redis is disabled or we're in development without Redis
-    if broker_url.startswith('memory://') or broker_url.startswith('rpc://'):
-        app.conf.update(
-            broker_url=broker_url,
-            result_backend=getattr(settings, 'CELERY_RESULT_BACKEND', 'rpc://'),
-            task_always_eager=True,  # Execute tasks synchronously
-            task_eager_propagates=True,
-        )
-        logging.info("Celery configured with memory/RPC broker for development")
-    else:
-        # Try to configure Redis broker
-        try:
-            import redis
-            # Test Redis connection
-            redis_url = broker_url.replace('/0', '')  # Remove database number for connection test
-            r = redis.Redis.from_url(redis_url, socket_connect_timeout=2, socket_timeout=2)
-            r.ping()
-            logging.info("Redis connection successful, using Redis broker")
-        except Exception as e:
-            logging.warning(f"Redis connection failed: {e}. Falling back to memory broker.")
-            app.conf.update(
-                broker_url='memory://',
-                result_backend='rpc://',
-                task_always_eager=True,
-                task_eager_propagates=True,
-            )
-
-# Configure broker on startup
-configure_celery_broker()
+# Broker, result backend and task_always_eager all come from settings via
+# config_from_object (CELERY_BROKER_URL / CELERY_RESULT_BACKEND /
+# CELERY_TASK_ALWAYS_EAGER). We deliberately do NOT auto-detect Redis and flip
+# to an in-memory/eager broker on a transient ping failure — that silently ran
+# tasks synchronously in the web process and masked broker misconfig. To run
+# without a broker (local dev), set CELERY_TASK_ALWAYS_EAGER=True explicitly.
 
 # Ensure Django is fully initialized before beat scheduler starts
 # This is critical when running worker + beat in the same process

--- a/maintenance_dashboard/settings.py
+++ b/maintenance_dashboard/settings.py
@@ -436,6 +436,10 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+# Run tasks synchronously in-process (no broker) only when explicitly opted in
+# — e.g. local dev without Redis. Never auto-enabled on a broker hiccup.
+CELERY_TASK_ALWAYS_EAGER = config('CELERY_TASK_ALWAYS_EAGER', default=False, cast=bool)
+CELERY_TASK_EAGER_PROPAGATES = True
 
 # Caching Configuration
 # Use Redis if available, fall back to database for development


### PR DESCRIPTION
## What I found
The Celery setup is actually **sound**: each stack runs a `celery` container as `worker --beat` (embedded beat) with the `django_celery_beat` DatabaseScheduler and 6 scheduled tasks (`CELERY_BEAT_SCHEDULE`).

The "Celery Worker offline" was a **reporting artifact**: the `/0/0` broker bug (fixed in the redis-url PR #161) only affected the **web** container — which has no explicit `CELERY_BROKER_URL` and is where the health check runs. The `celery` containers set `CELERY_BROKER_URL=redis://…/0` explicitly, so the worker was connected the whole time.

## Refactor
- **`celery.py`** — removed `configure_celery_broker()`. It re-derived the broker, ran a hacky `replace('/0','')` Redis ping, and on *any* transient failure silently flipped to `task_always_eager=True` + memory broker — i.e. ran tasks **synchronously in the web process** and hid broker misconfig. Broker / result backend / eager now come from settings via `config_from_object`. Also removed a duplicate `import os`.
- **`settings.py`** — added `CELERY_TASK_ALWAYS_EAGER` (opt-in, default `False`) for brokerless local dev, instead of auto-switching.
- **`check_celery_beat_health`** — the fixed 10-min staleness threshold perpetually false-warned (most frequent task runs every 2h). Now threshold ≈ 2× the smallest scheduled interval + 5m, so a healthy beat reads healthy.

## Net
With #161 + this, after a redeploy: **Cache, Celery Worker, and Celery Beat should all read healthy**, and task scheduling is unchanged. No behavior change to actual task execution (eager stays off in dev/prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)