### PR TITLE
fix(mobile): calendar heading, equipment header, activity checkbox

### DIFF
--- a/templates/equipment/equipment_list.html
+++ b/templates/equipment/equipment_list.html
@@ -212,7 +212,7 @@
 {% block content %}
 <!-- Equipment Filters Header -->
 <div class="equipment-header">
-    <div class="d-flex justify-content-between align-items-center mb-2">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
         <h5 class="mb-0 text-white">
             <i class="fas fa-cogs me-2"></i>
             Equipment Management

--- a/templates/events/calendar.html
+++ b/templates/events/calendar.html
@@ -640,6 +640,17 @@
         align-items: flex-start;
         gap: 10px;
     }
+
+    /* Calendar toolbar: stack + shrink the oversized month heading on mobile */
+    .fc-toolbar { padding: 10px; }
+    .fc .fc-toolbar.fc-header-toolbar {
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+    .fc-toolbar-title { font-size: 1.05rem; }
+    .fc-toolbar-chunk { display: flex; justify-content: center; flex-wrap: wrap; gap: 4px; }
+    .fc-button { padding: 4px 8px; font-size: 0.8rem; }
 }
 
 /* Legend */

--- a/templates/maintenance/activity_list.html
+++ b/templates/maintenance/activity_list.html
@@ -4,6 +4,27 @@
 
 {% block title %}Maintenance Activities{% endblock %}
 
+{% block extra_css %}
+<style>
+/* Highlight selected rows so the selection is obvious even when the table is
+   scrolled horizontally on mobile. */
+.table tbody tr.row-selected td { background-color: rgba(66, 153, 225, 0.22) !important; }
+
+/* Keep the checkbox column pinned/visible while scrolling the wide table on
+   mobile, so it stays aligned with its row. */
+@media (max-width: 991.98px) {
+    #bulkDeleteForm .table thead th:first-child,
+    #bulkDeleteForm .table tbody td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 2;
+        background-color: #2d3748;
+    }
+    #bulkDeleteForm .table tbody tr.row-selected td:first-child { background-color: #2b4d6f; }
+}
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="container-fluid">
     <div class="row">
@@ -170,6 +191,11 @@ document.addEventListener('DOMContentLoaded', function () {
             selectAll.checked = checked > 0 && checked === all.length;
             selectAll.indeterminate = checked > 0 && checked < all.length;
         }
+        // Highlight selected rows (visible even when scrolled horizontally).
+        all.forEach(function (c) {
+            var tr = c.closest('tr');
+            if (tr) tr.classList.toggle('row-selected', c.checked);
+        });
     }
     if (selectAll) selectAll.addEventListener('change', function () {
         items().forEach(function (c) { c.checked = selectAll.checked; });


### PR DESCRIPTION
From the mobile testing notes (3 issues):

1. **Calendar heading huge** — the FullCalendar toolbar wasn't styled for mobile. Now (≤768px) the toolbar stacks, the month title shrinks to ~1rem, button chunks wrap, and buttons are smaller.
2. **Misaligned equipment list header** — the title + Add/Import buttons row now uses `flex-wrap` so it wraps cleanly instead of misaligning/overflowing on narrow screens.
3. **Checkbox confusing on scroll** — on the activity list, selected rows are now **highlighted**, and the **checkbox column is sticky-left** on mobile so it stays visible and aligned with its row while the wide table scrolls horizontally.

## Verify (mobile / narrow)
- Calendar: month heading is reasonably sized; toolbar buttons fit.
- Equipment list: header buttons wrap under the title instead of overlapping.
- Activities: tick a row → it highlights; scroll the table sideways → the checkbox stays put and selection is obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)