### PR TITLE
fix(deploy): set ALLOWED_HOSTS on prod celery service (worker crash-loop)

### DIFF
--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -205,6 +205,17 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-SecureProdPassword2024!}
       - REDIS_URL=redis://redis:6379/0
       - C_FORCE_ROOT=1
+      # Django settings (required: settings fail loud if ALLOWED_HOSTS unset while DEBUG=off)
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-maintenance.errorlog.app,10.0.0.28,localhost,127.0.0.1}
+      - CSRF_TRUSTED_ORIGINS=https://maintenance.errorlog.app,https://www.maintenance.errorlog.app
+      - DOMAIN=${DOMAIN:-errorlog.app}
+      # Email (worker sends reminder/notification mail via the postfix-relay sidecar)
+      - EMAIL_BACKEND=${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
+      - EMAIL_HOST=${EMAIL_HOST:-postfix-relay}
+      - EMAIL_PORT=${EMAIL_PORT:-25}
+      - EMAIL_USE_TLS=${EMAIL_USE_TLS:-False}
+      - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-no-reply@errorlog.app}
+      - SERVER_EMAIL=${SERVER_EMAIL:-no-reply@errorlog.app}
       # Celery Production Settings
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0


### PR DESCRIPTION
## Root cause
The prod `celery` container (worker+beat) was crash-looping on:
```
ImproperlyConfigured: ALLOWED_HOSTS must be set when DEBUG is off.
```
Its environment block had DB/Redis/Celery vars but **no `ALLOWED_HOSTS`** — the `web` service had it, so web ran fine while celery died. Once the PR1 settings hardening made `ALLOWED_HOSTS` mandatory under `DEBUG=False`, the worker never started → beat/worker silently dead (no reminders, no due-date recompute) for ~2.5 days. (Dev stack runs `DEBUG=True`, so its celery was unaffected — matching what we saw.)

## Fix
Mirror the web service env onto `celery`: `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `DOMAIN`, plus `EMAIL_*`/`DEFAULT_FROM_EMAIL` so the worker can actually send reminder mail.

## After deploy
Redeploy the prod stack (or just add `ALLOWED_HOSTS` to the celery service env in Portainer and recreate the container). `/api/v1/diagnostics/health/` celery_worker + celery_beat should flip to healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)