### PR TITLE
feat(map): nested sub-location drill-down (POD › MDC › Cabinet › equipment)

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -141,51 +141,65 @@ def _build_site_layout(site):
         return {'id': e.id, 'name': e.name, 'health': health, 'open_issues': total,
                 'tooltip': " • ".join(tip)}
 
-    # Group equipment into tiles. The MDC is the chain element directly below the
-    # POD; equipment sitting directly on a POD (no MDC) is bucketed BY EQUIPMENT
-    # CATEGORY instead of one generic "Unzoned" tile — so e.g. a POD's transformer
-    # shows up as a "Transformer" tile. Tile keys: an int (real MDC location id) or
-    # ('cat', category_id) for a synthetic category tile (no backing location).
-    groups = {p.id: {} for p in pods}   # pod_id -> { key: {'mdc': loc|None, 'label': str, 'eq': []} }
+    # Build the location/equipment tree. Each POD's tiles are its direct child
+    # locations (MDCs, cabinets, …); within a tile, sub-locations nest recursively
+    # to arbitrary depth (POD › MDC › Network Cabinet › switches). Equipment sitting
+    # directly on a POD (no sub-location) is bucketed BY CATEGORY into synthetic
+    # tiles ("Transformer", "VFD", …) instead of one generic "Unzoned" tile.
+    HEALTH_LEVELS = ('critical', 'warning', 'maintenance', 'ok', 'idle')
+    eq_by_loc = {}
     for e in equipment:
-        chain, loc = [], e.location
-        while loc is not None:
-            chain.append(loc)
-            loc = loc.parent_location
-        pod = next((l for l in chain if l.id in pod_ids), None)
-        if not pod:
-            continue
-        idx = chain.index(pod)
-        mdc = chain[idx - 1] if idx > 0 else None
-        if mdc is not None:
-            grp = groups[pod.id].setdefault(mdc.id, {'mdc': mdc, 'label': mdc.name, 'eq': []})
-        else:
-            cat = e.category
-            key = ('cat', cat.id if cat else None)
-            label = cat.name if cat else 'Unzoned'
-            grp = groups[pod.id].setdefault(key, {'mdc': None, 'label': label, 'eq': []})
-        grp['eq'].append(e)
+        eq_by_loc.setdefault(e.location_id, []).append(e)
+    children_by_loc = {}
+    for loc in Location.objects.filter(id__in=site_loc_ids):
+        if loc.parent_location_id:
+            children_by_loc.setdefault(loc.parent_location_id, []).append(loc)
 
-    # Include every MDC under each POD even if it has no equipment yet.
-    mdc_by_pod = {}
-    for p in pods:
-        mdcs = sorted(Location.objects.filter(parent_location=p, is_active=True),
-                      key=lambda l: natural_sort_key(l.name))
-        mdc_by_pod[p.id] = mdcs
-        for m in mdcs:
-            groups[p.id].setdefault(m.id, {'mdc': m, 'label': m.name, 'eq': []})
+    def build_node(loc):
+        """Recursive sub-location node: its equipment + nested child locations,
+        with equipment counts aggregated over the whole subtree."""
+        eqs = [eq_payload(e) for e in sorted(eq_by_loc.get(loc.id, []),
+                                             key=lambda e: natural_sort_key(e.name))]
+        kids = [build_node(c) for c in sorted(children_by_loc.get(loc.id, []),
+                                              key=lambda l: natural_sort_key(l.name))]
+        counts = {lvl: 0 for lvl in HEALTH_LEVELS}
+        for ep in eqs:
+            counts[ep['health']] += 1
+        total = len(eqs)
+        for k in kids:
+            total += k['count']
+            for lvl in HEALTH_LEVELS:
+                counts[lvl] += k['counts'][lvl]
+        return {'id': loc.id, 'name': loc.name, 'equipment': eqs,
+                'children': kids, 'count': total, 'counts': counts}
 
-    # Flow PODs left-to-right, wrapping; grid MDC tiles inside each POD.
+    # Flow PODs left-to-right, wrapping; grid the tiles inside each POD.
     x_cur, y_cur, row_h = PAD, PAD, 0
     pods_payload = []
     for p in pods:
-        g = groups[p.id]
-        # Real MDC tiles first (natural order), then synthetic category tiles by label.
-        ordered = [(m.id, g[m.id]) for m in mdc_by_pod[p.id]]
-        cat_keys = sorted((k for k in g if isinstance(k, tuple)),
-                          key=lambda k: natural_sort_key(g[k]['label']))
-        ordered.extend((k, g[k]) for k in cat_keys)
-        n = max(1, len(ordered))
+        # Tiles = direct child locations (shown if active or non-empty) ...
+        tiles = []
+        for child in sorted(children_by_loc.get(p.id, []), key=lambda l: natural_sort_key(l.name)):
+            node = build_node(child)
+            if child.is_active or node['count'] > 0:
+                tiles.append((child, node))
+        # ... plus per-category buckets for equipment sitting directly on the POD.
+        cat_buckets = {}
+        for e in sorted(eq_by_loc.get(p.id, []), key=lambda e: natural_sort_key(e.name)):
+            cat = e.category
+            b = cat_buckets.setdefault(cat.id if cat else None,
+                                       {'label': cat.name if cat else 'Unzoned', 'eq': []})
+            b['eq'].append(e)
+        for key in sorted(cat_buckets, key=lambda k: natural_sort_key(cat_buckets[k]['label'])):
+            b = cat_buckets[key]
+            eqs = [eq_payload(e) for e in b['eq']]
+            counts = {lvl: 0 for lvl in HEALTH_LEVELS}
+            for ep in eqs:
+                counts[ep['health']] += 1
+            tiles.append((None, {'id': None, 'name': b['label'], 'equipment': eqs,
+                                 'children': [], 'count': len(eqs), 'counts': counts}))
+
+        n = max(1, len(tiles))
         cols = max(1, int(math.ceil(math.sqrt(n))))
         rows = int(math.ceil(n / cols))
         comp_w = cols * TILE_W + (cols + 1) * TPAD
@@ -201,26 +215,22 @@ def _build_site_layout(site):
         row_h = max(row_h, comp_h)
 
         mdcs_payload = []
-        for i, (mid, data) in enumerate(ordered):
+        for i, (loc, node) in enumerate(tiles):
             r, c = divmod(i, cols)
-            mdc = data['mdc']
             tx = px + TPAD + c * (TILE_W + TPAD)
             ty = py + HEADER + TPAD + r * (TILE_H + TPAD)
-            if mdc is not None and mdc.layout_x is not None:
-                tx, ty = mdc.layout_x, mdc.layout_y
-            tw = (mdc.layout_width if mdc and mdc.layout_width else TILE_W)
-            th = (mdc.layout_height if mdc and mdc.layout_height else TILE_H)
-            eqs = [eq_payload(e) for e in sorted(data['eq'], key=lambda e: natural_sort_key(e.name))]
-            counts = {lvl: 0 for lvl in ('critical', 'warning', 'maintenance', 'ok', 'idle')}
-            for e in eqs:
-                counts[e['health']] += 1
+            if loc is not None and loc.layout_x is not None:
+                tx, ty = loc.layout_x, loc.layout_y
+            tw = (loc.layout_width if loc and loc.layout_width else TILE_W)
+            th = (loc.layout_height if loc and loc.layout_height else TILE_H)
             mdcs_payload.append({
-                # Real MDC -> its location id (draggable/saveable); synthetic
-                # category tile -> null id (renders + expands, excluded from save).
-                'id': (mid if isinstance(mid, int) else None),
-                'name': data['label'],
+                # Real location -> its id (draggable/saveable); synthetic category
+                # tile -> null id (renders + expands, excluded from layout save).
+                'id': (loc.id if loc is not None else None),
+                'name': node['name'],
                 'x': round(tx, 1), 'y': round(ty, 1), 'w': round(tw, 1), 'h': round(th, 1),
-                'count': len(eqs), 'counts': counts, 'equipment': eqs,
+                'count': node['count'], 'counts': node['counts'],
+                'equipment': node['equipment'], 'children': node['children'],
             })
 
         pods_payload.append({

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -64,9 +64,22 @@
 .mdc-tile.expanded .mdc-caret { transform: rotate(90deg); }
 .mdc-empty { color: #718096; font-size: 11px; padding: 2px 4px; }
 
+/* nested sub-location groups (POD › MDC › Cabinet › …), collapsible */
+.subloc { width: 100%; border: 1px solid #3a4760; border-radius: 4px; margin: 2px 0; background: #222c40; }
+.subloc-header { display: flex; justify-content: space-between; align-items: center; gap: 6px;
+    padding: 3px 6px; font-size: 10px; font-weight: 600; color: #cbd5e0; cursor: pointer; white-space: nowrap; }
+.subloc-header:hover { background: #2a3550; }
+.subloc-name { overflow: hidden; text-overflow: ellipsis; }
+.subloc-count { color: #a0aec0; font-weight: 400; }
+.subloc-caret { color: #718096; font-size: 8px; display: inline-block; }
+.subloc-body { display: none; flex-wrap: wrap; gap: 4px; padding: 4px 6px; }
+.subloc.expanded > .subloc-body { display: flex; }
+.subloc.expanded > .subloc-header .subloc-caret { transform: rotate(90deg); }
+
 .eq-chip { font-size: 10px; line-height: 1.2; padding: 2px 5px; border-radius: 3px;
-    border: 1px solid; color: #fff; cursor: pointer; white-space: nowrap; }
-.eq-chip:hover { filter: brightness(1.2); outline: 1px solid #fff; }
+    border: 1px solid; color: #fff; cursor: pointer; white-space: nowrap;
+    text-decoration: none; display: inline-block; }
+.eq-chip:hover { filter: brightness(1.2); outline: 1px solid #fff; color: #fff; }
 
 .map-empty { text-align:center; padding:60px 20px; color:#a0aec0; }
 .map-empty i { font-size:46px; color:#4a5568; margin-bottom:16px; }
@@ -160,6 +173,43 @@
 
     function px(el, p) { return parseFloat(el.style[p]) || 0; }
 
+    // ----- equipment chips + recursive sub-location rendering -----
+    function makeChip(eq) {
+        var chip = document.createElement('a');
+        chip.className = 'eq-chip h-' + eq.health;
+        chip.href = '/equipment/' + eq.id + '/';
+        chip.title = eq.tooltip;
+        chip.textContent = eq.name + (eq.open_issues ? ' (' + eq.open_issues + ')' : '');
+        chip.addEventListener('click', function (ev) { ev.stopPropagation(); });
+        return chip;
+    }
+    function makeSubGroup(node) {
+        var g = document.createElement('div');
+        g.className = 'subloc';
+        var h = document.createElement('div');
+        h.className = 'subloc-header';
+        h.innerHTML = '<span class="subloc-name">' + escapeHtml(node.name) +
+            '</span><span class="subloc-count">' + node.count +
+            ' <span class="subloc-caret">&#9656;</span></span>';
+        h.addEventListener('click', function (ev) { ev.stopPropagation(); g.classList.toggle('expanded'); });
+        g.appendChild(h);
+        var b = document.createElement('div');
+        b.className = 'subloc-body';
+        fillNodeBody(b, node);
+        g.appendChild(b);
+        return g;
+    }
+    // Fill a body element with a node's direct equipment, then its nested children.
+    function fillNodeBody(body, node) {
+        var eqs = node.equipment || [], kids = node.children || [];
+        if (!eqs.length && !kids.length) {
+            body.innerHTML = '<span class="mdc-empty">No equipment</span>';
+            return;
+        }
+        eqs.forEach(function (eq) { body.appendChild(makeChip(eq)); });
+        kids.forEach(function (child) { body.appendChild(makeSubGroup(child)); });
+    }
+
     var hasContent = layout.pods && layout.pods.length;
     if (!hasContent) {
         wrap.style.display = 'none';
@@ -228,24 +278,10 @@
             });
             tile.appendChild(sum);
 
-            // body (equipment chips, revealed on expand)
+            // body: equipment chips + nested sub-location groups, revealed on expand
             var body = document.createElement('div');
             body.className = 'mdc-body';
-            if (!mdc.equipment.length) {
-                body.innerHTML = '<span class="mdc-empty">No equipment</span>';
-            } else {
-                mdc.equipment.forEach(function (eq) {
-                    var chip = document.createElement('div');
-                    chip.className = 'eq-chip h-' + eq.health;
-                    chip.title = eq.tooltip;
-                    chip.textContent = eq.name + (eq.open_issues ? ' (' + eq.open_issues + ')' : '');
-                    chip.addEventListener('click', function (ev) {
-                        ev.stopPropagation();
-                        window.location.href = '/equipment/' + eq.id + '/';
-                    });
-                    body.appendChild(chip);
-                });
-            }
+            fillNodeBody(body, mdc);
             tile.appendChild(body);
 
             canvas.appendChild(tile);


### PR DESCRIPTION
Implements the nested sub-tile drill-down you picked. Builds on #171/#172.

## What
The map collapsed everything below a POD's direct child into one flat chip list, so deeper containers (e.g. a **Network Cabinet** of switches/servers under an MDC) lost their grouping. Now each tile holds a **recursive tree** — sub-locations render as **collapsible nested groups** to arbitrary depth (POD › MDC › Cabinet › …), each with its own equipment and an aggregated count/health summary.

## Changes
- `_build_site_layout`: recursive `build_node` per tile; tile health counts + count aggregate over the whole subtree. POD-direct equipment still buckets by **category** (Transformer/VFD/…). Direct-child locations shown if active or non-empty.
- `map.html`: renders the tree (`fillNodeBody`/`makeSubGroup`) with collapsible sub-groups; **equipment chips are now real `<a>` links** to the detail page (cmd-click opens a new tab).
- Draggable layout unchanged: real location tiles still save position; nested `.subloc` groups carry no `data-id` so they're excluded from save. `save_map_layout` already allows any location id under the site.

## Verify
`manage.py check` clean; template renders. Needs a dev eyeball with a real sub-location: create e.g. `POD › MDC › Network Cabinet`, put a couple switches in it → the MDC tile expands to show a collapsible "Network Cabinet" group listing the switches; clicking a switch opens its detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)