### PR TITLE
feat(map): group equipment by category inside every container (recursive)

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -155,22 +155,43 @@ def _build_site_layout(site):
         if loc.parent_location_id:
             children_by_loc.setdefault(loc.parent_location_id, []).append(loc)
 
+    def category_groups(eq_list):
+        """Group a flat equipment list into expandable per-category groups
+        (Transformer, Switchgear, PDU, …) so types are never mixed/mistaken."""
+        buckets = {}
+        for e in eq_list:
+            cat = e.category
+            b = buckets.setdefault(cat.id if cat else None,
+                                   {'name': cat.name if cat else 'Uncategorized', 'eq': []})
+            b['eq'].append(e)
+        groups = []
+        for key in sorted(buckets, key=lambda k: natural_sort_key(buckets[k]['name'])):
+            b = buckets[key]
+            chips = [eq_payload(e) for e in sorted(b['eq'], key=lambda e: natural_sort_key(e.name))]
+            counts = {lvl: 0 for lvl in HEALTH_LEVELS}
+            for ep in chips:
+                counts[ep['health']] += 1
+            groups.append({'name': b['name'], 'equipment': chips,
+                           'count': len(chips), 'counts': counts})
+        return groups
+
     def build_node(loc):
-        """Recursive sub-location node: its equipment + nested child locations,
-        with equipment counts aggregated over the whole subtree."""
-        eqs = [eq_payload(e) for e in sorted(eq_by_loc.get(loc.id, []),
-                                             key=lambda e: natural_sort_key(e.name))]
+        """Recursive sub-location node: its direct equipment grouped by category,
+        plus nested child locations. Counts aggregate over the whole subtree."""
+        eq_groups = category_groups(eq_by_loc.get(loc.id, []))
         kids = [build_node(c) for c in sorted(children_by_loc.get(loc.id, []),
                                               key=lambda l: natural_sort_key(l.name))]
         counts = {lvl: 0 for lvl in HEALTH_LEVELS}
-        for ep in eqs:
-            counts[ep['health']] += 1
-        total = len(eqs)
+        total = 0
+        for g in eq_groups:
+            total += g['count']
+            for lvl in HEALTH_LEVELS:
+                counts[lvl] += g['counts'][lvl]
         for k in kids:
             total += k['count']
             for lvl in HEALTH_LEVELS:
                 counts[lvl] += k['counts'][lvl]
-        return {'id': loc.id, 'name': loc.name, 'equipment': eqs,
+        return {'id': loc.id, 'name': loc.name, 'equipment_groups': eq_groups,
                 'children': kids, 'count': total, 'counts': counts}
 
     # Flow PODs left-to-right, wrapping; grid the tiles inside each POD.
@@ -230,7 +251,11 @@ def _build_site_layout(site):
                 'name': node['name'],
                 'x': round(tx, 1), 'y': round(ty, 1), 'w': round(tw, 1), 'h': round(th, 1),
                 'count': node['count'], 'counts': node['counts'],
-                'equipment': node['equipment'], 'children': node['children'],
+                # Category tiles carry flat 'equipment'; location tiles carry
+                # 'equipment_groups' (category groups) + nested 'children'.
+                'equipment': node.get('equipment', []),
+                'equipment_groups': node.get('equipment_groups', []),
+                'children': node.get('children', []),
             })
 
         pods_payload.append({

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -70,6 +70,9 @@
     padding: 3px 6px; font-size: 10px; font-weight: 600; color: #cbd5e0; cursor: pointer; white-space: nowrap; }
 .subloc-header:hover { background: #2a3550; }
 .subloc-name { overflow: hidden; text-overflow: ellipsis; }
+.subloc-icon { font-size: 9px; margin-right: 2px; color: #718096; }
+.subloc-cat > .subloc-header .subloc-icon { color: #63b3ed; }   /* category = blue */
+.subloc-loc > .subloc-header .subloc-icon { color: #a0aec0; }   /* location = grey */
 .subloc-count { color: #a0aec0; font-weight: 400; }
 .subloc-caret { color: #718096; font-size: 8px; display: inline-block; }
 .subloc-body { display: none; flex-wrap: wrap; gap: 4px; padding: 4px 6px; }
@@ -183,12 +186,16 @@
         chip.addEventListener('click', function (ev) { ev.stopPropagation(); });
         return chip;
     }
-    function makeSubGroup(node) {
+    function makeSubGroup(node, kind) {
         var g = document.createElement('div');
-        g.className = 'subloc';
+        g.className = 'subloc subloc-' + (kind || 'loc');
+        // location groups get a folder icon, category groups a layer/type icon
+        var icon = kind === 'cat'
+            ? '<i class="fas fa-layer-group subloc-icon"></i> '
+            : '<i class="fas fa-folder subloc-icon"></i> ';
         var h = document.createElement('div');
         h.className = 'subloc-header';
-        h.innerHTML = '<span class="subloc-name">' + escapeHtml(node.name) +
+        h.innerHTML = '<span class="subloc-name">' + icon + escapeHtml(node.name) +
             '</span><span class="subloc-count">' + node.count +
             ' <span class="subloc-caret">&#9656;</span></span>';
         h.addEventListener('click', function (ev) { ev.stopPropagation(); g.classList.toggle('expanded'); });
@@ -199,15 +206,18 @@
         g.appendChild(b);
         return g;
     }
-    // Fill a body element with a node's direct equipment, then its nested children.
+    // Fill a body element with: flat equipment chips (category-tile leaves),
+    // then per-category groups, then nested sub-location children. Category groups
+    // and location children both render via makeSubGroup -> fillNodeBody (recursive).
     function fillNodeBody(body, node) {
-        var eqs = node.equipment || [], kids = node.children || [];
-        if (!eqs.length && !kids.length) {
+        var flat = node.equipment || [], groups = node.equipment_groups || [], kids = node.children || [];
+        if (!flat.length && !groups.length && !kids.length) {
             body.innerHTML = '<span class="mdc-empty">No equipment</span>';
             return;
         }
-        eqs.forEach(function (eq) { body.appendChild(makeChip(eq)); });
-        kids.forEach(function (child) { body.appendChild(makeSubGroup(child)); });
+        flat.forEach(function (eq) { body.appendChild(makeChip(eq)); });
+        groups.forEach(function (g) { body.appendChild(makeSubGroup(g, 'cat')); });
+        kids.forEach(function (child) { body.appendChild(makeSubGroup(child, 'loc')); });
     }
 
     var hasContent = layout.pods && layout.pods.length;


### PR DESCRIPTION
Refines the nested drill-down (#173) per feedback: apply the **category grouping** (Transformer/Switchgear/PDU) — the thing we did at POD level — **inside every container, recursively**.

## What
Expanding an MDC (or any sub-location) now shows:
- **Per-category groups** of its direct equipment — "Transformer (2)", "Switchgear (1)", "PDU (5)" — each expandable to the chips (📚 layer-group icon, blue).
- **Nested location groups** — e.g. "Network Cabinet" (📁 folder icon, grey) — which recurse the *same way*.

So PDUs in a sub-sub-location sit under **that location's own "PDU" group** and can't be confused with PDUs elsewhere.

## How
- `build_node`: direct equipment → `category_groups()`; node carries `equipment_groups` + `children`; counts aggregate over the whole subtree.
- `map.html`: `fillNodeBody` renders flat chips (POD-level category tiles) | category groups | nested location children. `makeSubGroup` is generic — a category group is a leaf (chips), a location recurses.
- Layout/save unchanged; equipment chips still link to detail.

## Verify
`manage.py check` clean; template renders. Dev eyeball: an MDC with mixed gear should expand into category groups; a Network Cabinet under it should expand into its own category groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)