### PR TITLE
feat(map): grid layout engine + snap-to-grid drag + CSV import

### DIFF
--- a/core/migrations/0029_location_grid_row_col.py
+++ b/core/migrations/0029_location_grid_row_col.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0028_location_layout_height_location_layout_width_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='location',
+            name='grid_row',
+            field=models.PositiveSmallIntegerField(blank=True, null=True, help_text='Facility-map grid row (0-based)'),
+        ),
+        migrations.AddField(
+            model_name='location',
+            name='grid_col',
+            field=models.PositiveSmallIntegerField(blank=True, null=True, help_text='Facility-map grid column (0-based)'),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -168,6 +168,12 @@ class Location(TimeStampedModel):
     layout_width = models.FloatField(null=True, blank=True, help_text="Facility-map width (or canvas width for a site)")
     layout_height = models.FloatField(null=True, blank=True, help_text="Facility-map height (or canvas height for a site)")
 
+    # Facility-map GRID placement (preferred over free-form layout_x/y when set).
+    # A POD's cell on its site's grid; an MDC's cell within its POD's grid.
+    # Zero-based. Null until placed via snap-to-grid drag or CSV import.
+    grid_row = models.PositiveSmallIntegerField(null=True, blank=True, help_text="Facility-map grid row (0-based)")
+    grid_col = models.PositiveSmallIntegerField(null=True, blank=True, help_text="Facility-map grid column (0-based)")
+
     # Custom manager for natural sorting
     objects = NaturalSortManager()
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('version/form/', views.version_form_view, name='version_form'),
     path('map/', views.map_view, name='map_view'),
     path('map/layout/save/', views.save_map_layout, name='save_map_layout'),
+    path('map/layout/import/', views.import_map_layout, name='import_map_layout'),
     path('locations/settings/', views.locations_settings, name='locations_settings'),
     path('equipment-items/settings/', views.equipment_items_settings, name='equipment_items_settings'),
     path('equipment-conditional-fields/settings/', views.equipment_conditional_fields_settings, name='equipment_conditional_fields_settings'),

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -419,6 +419,82 @@ def save_map_layout(request):
     return JsonResponse({'success': True, 'zones_saved': zones_saved})
 
 
+@permission_required('site_map.write')
+@require_http_methods(["GET", "POST"])
+def import_map_layout(request):
+    """CSV import for the facility-map grid. GET returns a template; POST ingests
+    a CSV (columns: pod,pod_row,pod_col,mdc,mdc_row,mdc_col) and CREATES any
+    missing POD/MDC locations under the selected site, then sets their grid cells.
+    A blank mdc places just the POD. Coordinates are 0-based; blank = leave as-is."""
+    if request.method == 'GET':
+        sample = ("pod,pod_row,pod_col,mdc,mdc_row,mdc_col\n"
+                  "POD 1,0,0,MDC 1,0,0\n"
+                  "POD 1,0,0,MDC 2,0,1\n"
+                  "POD 2,0,1,,,\n")
+        resp = HttpResponse(sample, content_type='text/csv')
+        resp['Content-Disposition'] = 'attachment; filename="map_layout_template.csv"'
+        return resp
+
+    site = get_object_or_404(Location, id=request.POST.get('site_id'), is_site=True)
+    upload = request.FILES.get('file')
+    if not upload:
+        return JsonResponse({'success': False, 'error': 'No CSV file uploaded.'}, status=400)
+    try:
+        text = upload.read().decode('utf-8-sig')
+    except Exception:
+        return JsonResponse({'success': False, 'error': 'Could not read the file as UTF-8 text.'}, status=400)
+
+    def norm(k):
+        return (k or '').strip().lower().replace(' ', '_')
+
+    def gi(v):
+        v = (v or '').strip()
+        if not v:
+            return None
+        try:
+            return max(0, int(float(v)))
+        except (TypeError, ValueError):
+            return None
+
+    pods_created = mdcs_created = positioned = 0
+    errors = []
+    pod_cache = {}
+    reader = csv.DictReader(StringIO(text))
+    for i, raw in enumerate(reader, start=2):  # row 1 is the header
+        row = {norm(k): (v or '').strip() for k, v in raw.items()}
+        pod_name = row.get('pod') or row.get('pod_name')
+        if not pod_name:
+            errors.append(f'Row {i}: missing "pod".')
+            continue
+        pod = pod_cache.get(pod_name.lower())
+        if pod is None:
+            pod, created = Location.objects.get_or_create(
+                name=pod_name, parent_location=site,
+                defaults={'is_site': False, 'is_active': True})
+            pods_created += 1 if created else 0
+            pod_cache[pod_name.lower()] = pod
+        pr, pc = gi(row.get('pod_row')), gi(row.get('pod_col'))
+        if pr is not None and pc is not None and (pod.grid_row, pod.grid_col) != (pr, pc):
+            pod.grid_row, pod.grid_col = pr, pc
+            pod.save(update_fields=['grid_row', 'grid_col'])
+            positioned += 1
+        mdc_name = row.get('mdc') or row.get('mdc_name')
+        if mdc_name:
+            mdc, created = Location.objects.get_or_create(
+                name=mdc_name, parent_location=pod,
+                defaults={'is_site': False, 'is_active': True})
+            mdcs_created += 1 if created else 0
+            mr, mc = gi(row.get('mdc_row')), gi(row.get('mdc_col'))
+            if mr is not None and mc is not None and (mdc.grid_row, mdc.grid_col) != (mr, mc):
+                mdc.grid_row, mdc.grid_col = mr, mc
+                mdc.save(update_fields=['grid_row', 'grid_col'])
+                positioned += 1
+
+    return JsonResponse({'success': True, 'pods_created': pods_created,
+                         'mdcs_created': mdcs_created, 'positioned': positioned,
+                         'errors': errors[:50]})
+
+
 @login_required
 @user_passes_test(is_staff_or_superuser)
 def locations_settings(request):
@@ -1257,4 +1333,4 @@ def bulk_locations_view(request):
     return render(request, 'core/bulk_locations.html', context)
 
 
-__all__ = ["map_view", "save_map_layout", "locations_settings", "locations_api", "location_detail_api", "add_location", "edit_location", "export_sites_csv", "import_sites_csv", "delete_location", "export_locations_csv", "import_locations_csv", "bulk_edit_locations", "bulk_locations_view"]
+__all__ = ["map_view", "save_map_layout", "import_map_layout", "locations_settings", "locations_api", "location_detail_api", "add_location", "edit_location", "export_sites_csv", "import_sites_csv", "delete_location", "export_locations_csv", "import_locations_csv", "bulk_edit_locations", "bulk_locations_view"]

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -361,7 +361,8 @@ def map_view(request):
 @require_POST
 def save_map_layout(request):
     """Persist facility-map zone positions from the drag editor. Accepts JSON:
-    {site_id, canvas:{width,height}, zones:[{id,x,y,w,h}]}.
+    {site_id, canvas:{width,height}, zones:[...]}. Each zone is either a grid
+    placement {id, grid_row, grid_col} (preferred) or legacy pixels {id,x,y,w,h}.
     Zones are POD/MDC locations under the site (validated)."""
     from core.utils import get_all_descendant_location_ids
     try:
@@ -389,6 +390,12 @@ def save_map_layout(request):
 
     # Zones are POD/MDC locations under this site. Restrict updates to that set.
     allowed_ids = set(get_all_descendant_location_ids(site, include_inactive=True))
+    def grid_int(v):
+        try:
+            return max(0, int(v))
+        except (TypeError, ValueError):
+            return None
+
     zones_saved = 0
     for z in data.get('zones', []):
         try:
@@ -397,10 +404,17 @@ def save_map_layout(request):
             continue
         if zid not in allowed_ids:
             continue
-        zones_saved += Location.objects.filter(id=zid).update(
-            layout_x=num(z.get('x')), layout_y=num(z.get('y')),
-            layout_width=num(z.get('w')), layout_height=num(z.get('h')),
-        )
+        if 'grid_row' in z or 'grid_col' in z:
+            # Grid placement (preferred): row/col cell on the site/POD grid.
+            zones_saved += Location.objects.filter(id=zid).update(
+                grid_row=grid_int(z.get('grid_row')), grid_col=grid_int(z.get('grid_col')),
+            )
+        else:
+            # Legacy free-form pixel placement.
+            zones_saved += Location.objects.filter(id=zid).update(
+                layout_x=num(z.get('x')), layout_y=num(z.get('y')),
+                layout_width=num(z.get('w')), layout_height=num(z.get('h')),
+            )
 
     return JsonResponse({'success': True, 'zones_saved': zones_saved})
 

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -194,22 +194,19 @@ def _build_site_layout(site):
         return {'id': loc.id, 'name': loc.name, 'equipment_groups': eq_groups,
                 'children': kids, 'count': total, 'counts': counts}
 
-    # Flow PODs left-to-right, wrapping; grid the tiles inside each POD.
-    x_cur, y_cur, row_h = PAD, PAD, 0
-    pods_payload = []
-    for p in pods:
-        # Tiles = direct child locations (shown if active or non-empty) ...
+    def build_pod_tiles(p):
+        """A POD's tiles: its direct child locations (shown if active or non-empty)
+        plus per-category buckets for equipment sitting directly on the POD."""
         tiles = []
         for child in sorted(children_by_loc.get(p.id, []), key=lambda l: natural_sort_key(l.name)):
             node = build_node(child)
             if child.is_active or node['count'] > 0:
                 tiles.append((child, node))
-        # ... plus per-category buckets for equipment sitting directly on the POD.
         cat_buckets = {}
         for e in sorted(eq_by_loc.get(p.id, []), key=lambda e: natural_sort_key(e.name)):
             cat = e.category
             b = cat_buckets.setdefault(cat.id if cat else None,
-                                       {'label': cat.name if cat else 'Unzoned', 'eq': []})
+                                       {'label': cat.name if cat else 'Uncategorized', 'eq': []})
             b['eq'].append(e)
         for key in sorted(cat_buckets, key=lambda k: natural_sort_key(cat_buckets[k]['label'])):
             b = cat_buckets[key]
@@ -219,31 +216,91 @@ def _build_site_layout(site):
                 counts[ep['health']] += 1
             tiles.append((None, {'id': None, 'name': b['label'], 'equipment': eqs,
                                  'children': [], 'count': len(eqs), 'counts': counts}))
+        return tiles
 
-        n = max(1, len(tiles))
-        cols = max(1, int(math.ceil(math.sqrt(n))))
-        rows = int(math.ceil(n / cols))
-        comp_w = cols * TILE_W + (cols + 1) * TPAD
-        comp_h = HEADER + rows * TILE_H + (rows + 1) * TPAD
+    def assign_cells(rc_list):
+        """Place items on a grid. Each item is an (row, col) pair where both are set
+        (explicit placement) or both None (auto). Explicit cells are honored; the
+        rest auto-fill row-major into free cells. Returns (cells, ncols)."""
+        n = len(rc_list)
+        explicit = [(r, c) for (r, c) in rc_list if r is not None and c is not None]
+        if not explicit:
+            ncols = max(1, int(math.ceil(math.sqrt(max(1, n)))))
+            return [divmod(i, ncols) for i in range(n)], ncols
+        ncols = max([c for (r, c) in explicit] + [int(math.ceil(math.sqrt(max(1, n)))) - 1]) + 1
+        used = set(explicit)
+        cells = [(r, c) if (r is not None and c is not None) else None for (r, c) in rc_list]
+        cursor = 0
+        for i in range(n):
+            if cells[i] is not None:
+                continue
+            while True:
+                rr, cc = divmod(cursor, ncols)
+                cursor += 1
+                if (rr, cc) not in used:
+                    used.add((rr, cc)); cells[i] = (rr, cc); break
+        return cells, ncols
 
-        if x_cur + comp_w > canvas_w and x_cur > PAD:
-            x_cur, y_cur, row_h = PAD, y_cur + row_h + PAD, 0
-        px = p.layout_x if p.layout_x is not None else x_cur
-        py = p.layout_y if p.layout_y is not None else y_cur
-        pw = p.layout_width or comp_w
-        ph = p.layout_height or comp_h
-        x_cur += comp_w + PAD
-        row_h = max(row_h, comp_h)
+    # Pass 1 — per-POD tiles, grid the MDC tiles inside each POD, derive POD size.
+    pod_meta = []
+    for p in pods:
+        tiles = build_pod_tiles(p)
+        rc = [((loc.grid_row, loc.grid_col) if loc is not None else (None, None))
+              for (loc, node) in tiles]
+        cells, ncols = assign_cells(rc)
+        nrows = max((r for (r, c) in cells), default=0) + 1
+        comp_w = ncols * TILE_W + (ncols + 1) * TPAD
+        comp_h = HEADER + nrows * TILE_H + (nrows + 1) * TPAD
+        pod_meta.append({'pod': p, 'tiles': tiles, 'cells': cells,
+                         'comp_w': comp_w, 'comp_h': comp_h})
 
+    # Pass 2 — position PODs. Grid (table: col widths / row heights sized to content)
+    # when any POD has a grid cell; otherwise legacy free-form / auto-flow wrapping.
+    pods_have_grid = any(m['pod'].grid_row is not None and m['pod'].grid_col is not None
+                         for m in pod_meta)
+    pod_pos = {}
+    if pods_have_grid:
+        cells, ncols = assign_cells([(m['pod'].grid_row, m['pod'].grid_col) for m in pod_meta])
+        nrows = max((r for (r, c) in cells), default=0) + 1
+        col_w, row_h = [0] * ncols, [0] * nrows
+        for m, (r, c) in zip(pod_meta, cells):
+            col_w[c] = max(col_w[c], m['comp_w'])
+            row_h[r] = max(row_h[r], m['comp_h'])
+        col_x, row_y = [PAD] * ncols, [PAD] * nrows
+        for c in range(1, ncols):
+            col_x[c] = col_x[c - 1] + col_w[c - 1] + PAD
+        for r in range(1, nrows):
+            row_y[r] = row_y[r - 1] + row_h[r - 1] + PAD
+        for m, (r, c) in zip(pod_meta, cells):
+            pod_pos[m['pod'].id] = (col_x[c], row_y[r], m['comp_w'], m['comp_h'])
+        canvas_h_auto = (row_y[-1] + row_h[-1] + PAD) if nrows else PAD
+    else:
+        x_cur, y_cur, rh = PAD, PAD, 0
+        for m in pod_meta:
+            p, comp_w, comp_h = m['pod'], m['comp_w'], m['comp_h']
+            if x_cur + comp_w > canvas_w and x_cur > PAD:
+                x_cur, y_cur, rh = PAD, y_cur + rh + PAD, 0
+            px = p.layout_x if p.layout_x is not None else x_cur
+            py = p.layout_y if p.layout_y is not None else y_cur
+            pod_pos[p.id] = (px, py, p.layout_width or comp_w, p.layout_height or comp_h)
+            x_cur += comp_w + PAD
+            rh = max(rh, comp_h)
+        canvas_h_auto = y_cur + rh + PAD
+
+    # Pass 3 — payloads, positioning each tile inside its POD.
+    pods_payload = []
+    for m in pod_meta:
+        p = m['pod']
+        px, py, pw, ph = pod_pos[p.id]
         mdcs_payload = []
-        for i, (loc, node) in enumerate(tiles):
-            r, c = divmod(i, cols)
+        for (loc, node), (r, c) in zip(m['tiles'], m['cells']):
             tx = px + TPAD + c * (TILE_W + TPAD)
             ty = py + HEADER + TPAD + r * (TILE_H + TPAD)
-            if loc is not None and loc.layout_x is not None:
+            # legacy pixel override only for non-grid sites where the MDC has one
+            if not pods_have_grid and loc is not None and loc.grid_col is None and loc.layout_x is not None:
                 tx, ty = loc.layout_x, loc.layout_y
-            tw = (loc.layout_width if loc and loc.layout_width else TILE_W)
-            th = (loc.layout_height if loc and loc.layout_height else TILE_H)
+            tw = (loc.layout_width if loc and loc.layout_width and loc.grid_col is None else TILE_W)
+            th = (loc.layout_height if loc and loc.layout_height and loc.grid_row is None else TILE_H)
             mdcs_payload.append({
                 # Real location -> its id (draggable/saveable); synthetic category
                 # tile -> null id (renders + expands, excluded from layout save).
@@ -257,14 +314,13 @@ def _build_site_layout(site):
                 'equipment_groups': node.get('equipment_groups', []),
                 'children': node.get('children', []),
             })
-
         pods_payload.append({
             'id': p.id, 'name': p.name,
             'x': round(px, 1), 'y': round(py, 1), 'w': round(pw, 1), 'h': round(ph, 1),
             'mdcs': mdcs_payload,
         })
 
-    canvas_h = site.layout_height or (y_cur + row_h + PAD)
+    canvas_h = site.layout_height or canvas_h_auto
     return {
         'site': {'id': site.id, 'name': site.name, 'width': canvas_w, 'height': canvas_h},
         'pods': pods_payload,

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -141,7 +141,7 @@
     </div>
 {% else %}
     <div id="editHint" class="text-info small mb-2" style="display:none;">
-        <i class="fas fa-info-circle me-1"></i> Drag POD or MDC headers to arrange; drag a POD corner to resize. Moving a POD moves its MDCs. Click <strong>Save</strong> when done.
+        <i class="fas fa-info-circle me-1"></i> Drag POD or MDC headers to arrange. On <strong>Save</strong>, zones snap to a clean grid (row/column) based on their arrangement — no more drift. Moving a POD moves its MDCs.
     </div>
     <div id="canvasWrap">
         <div id="canvasSizer">
@@ -408,10 +408,52 @@
             window.location.reload();
         });
 
+        // Infer a clean grid from a free-form arrangement: cluster items into rows
+        // by their Y (within a tolerance), then order each row by X -> (row, col).
+        // This is the "snap to grid": drag roughly, Save snaps to tidy row/col cells.
+        function inferGrid(items) {
+            var ROW_TOL = 40;
+            var sorted = items.slice().sort(function (a, b) { return a.y - b.y; });
+            var rows = [];
+            sorted.forEach(function (it) {
+                var row = null;
+                for (var i = 0; i < rows.length; i++) {
+                    if (Math.abs(rows[i].y - it.y) <= ROW_TOL) { row = rows[i]; break; }
+                }
+                if (!row) { row = { y: it.y, items: [] }; rows.push(row); }
+                row.items.push(it);
+            });
+            rows.sort(function (a, b) { return a.y - b.y; });
+            var out = {};
+            rows.forEach(function (row, r) {
+                row.items.sort(function (a, b) { return a.x - b.x; });
+                row.items.forEach(function (it, c) { out[it.id] = { row: r, col: c }; });
+            });
+            return out;
+        }
+
         saveBtn && saveBtn.addEventListener('click', function () {
+            // PODs -> site grid cells
+            var podEls = [];
+            Array.prototype.forEach.call(canvas.querySelectorAll('.pod-zone[data-id]'), function (el) {
+                podEls.push({ id: parseInt(el.dataset.id, 10), x: px(el, 'left'), y: px(el, 'top') });
+            });
             var zones = [];
-            Array.prototype.forEach.call(canvas.querySelectorAll('.pod-zone[data-id], .mdc-tile[data-id]'), function (el) {
-                zones.push({ id: parseInt(el.dataset.id, 10), x: px(el, 'left'), y: px(el, 'top'), w: px(el, 'width'), h: px(el, 'height') });
+            var podGrid = inferGrid(podEls);
+            Object.keys(podGrid).forEach(function (id) {
+                zones.push({ id: parseInt(id, 10), grid_row: podGrid[id].row, grid_col: podGrid[id].col });
+            });
+            // MDC tiles -> per-POD grid cells
+            var byPod = {};
+            Array.prototype.forEach.call(canvas.querySelectorAll('.mdc-tile[data-id]'), function (el) {
+                var pid = el.dataset.podId || '_';
+                (byPod[pid] = byPod[pid] || []).push({ id: parseInt(el.dataset.id, 10), x: px(el, 'left'), y: px(el, 'top') });
+            });
+            Object.keys(byPod).forEach(function (pid) {
+                var g = inferGrid(byPod[pid]);
+                Object.keys(g).forEach(function (id) {
+                    zones.push({ id: parseInt(id, 10), grid_row: g[id].row, grid_col: g[id].col });
+                });
             });
             var token = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value;
             saveBtn.disabled = true; saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Saving...';

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -109,6 +109,36 @@
             <button type="button" id="autoFitBtn" class="btn btn-outline-info btn-sm" style="display:none;" title="Auto-arrange MDCs into a grid inside each POD"><i class="fas fa-th me-1"></i> Auto-fit</button>
             <button type="button" id="saveLayoutBtn" class="btn btn-success btn-sm" style="display:none;"><i class="fas fa-save me-1"></i> Save</button>
             <button type="button" id="cancelLayoutBtn" class="btn btn-secondary btn-sm" style="display:none;">Cancel</button>
+            <button type="button" class="btn btn-outline-warning btn-sm" data-toggle="modal" data-target="#importCsvModal" title="Build/arrange this site's layout from a CSV"><i class="fas fa-file-csv me-1"></i> Import CSV</button>
+        </div>
+        {% endif %}
+
+        {% if can_edit_map and selected_site %}
+        <div class="modal fade" id="importCsvModal" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title"><i class="fas fa-file-csv me-2"></i>Import layout — {{ selected_site.name }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              </div>
+              <div class="modal-body">
+                <p class="text-muted" style="font-size:.86rem;">
+                  Upload a CSV to <strong>create &amp; position</strong> PODs and MDCs on the grid.
+                  Columns: <code>pod, pod_row, pod_col, mdc, mdc_row, mdc_col</code> (0-based; blank
+                  <code>mdc</code> places just the POD). Missing locations are created under this site.
+                </p>
+                <a href="{% url 'core:import_map_layout' %}" class="btn btn-link btn-sm px-0">
+                  <i class="fas fa-download me-1"></i> Download template
+                </a>
+                <input type="file" id="importCsvFile" accept=".csv,text/csv" class="form-control mt-2">
+                <div id="importCsvResult" class="mt-2" style="font-size:.86rem;"></div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-warning" id="importCsvSubmit"><i class="fas fa-upload me-1"></i> Import</button>
+              </div>
+            </div>
+          </div>
         </div>
         {% endif %}
     </div>
@@ -220,11 +250,53 @@
         kids.forEach(function (child) { body.appendChild(makeSubGroup(child, 'loc')); });
     }
 
+    // CSV import — works even on an empty site (the main use case: build from scratch).
+    (function () {
+        var importBtn = document.getElementById('importCsvSubmit');
+        if (!importBtn) return;
+        importBtn.addEventListener('click', function () {
+            var fileInput = document.getElementById('importCsvFile');
+            var resultEl = document.getElementById('importCsvResult');
+            if (!fileInput.files.length) {
+                resultEl.innerHTML = '<span class="text-danger">Choose a CSV file first.</span>';
+                return;
+            }
+            var fd = new FormData();
+            fd.append('file', fileInput.files[0]);
+            fd.append('site_id', layout.site.id);
+            var token = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value;
+            importBtn.disabled = true; resultEl.textContent = 'Importing…';
+            fetch("{% url 'core:import_map_layout' %}", {
+                method: 'POST',
+                headers: { 'X-CSRFToken': token, 'X-Requested-With': 'XMLHttpRequest' },
+                body: fd
+            }).then(function (r) { return r.json(); }).then(function (resp) {
+                importBtn.disabled = false;
+                if (!resp.success) {
+                    resultEl.innerHTML = '<span class="text-danger">' + (resp.error || 'Import failed.') + '</span>';
+                    return;
+                }
+                var msg = 'Created ' + resp.pods_created + ' POD(s), ' + resp.mdcs_created +
+                    ' MDC(s); positioned ' + resp.positioned + '.';
+                if (resp.errors && resp.errors.length) msg += ' ' + resp.errors.length + ' row issue(s): ' + resp.errors.join('; ');
+                resultEl.innerHTML = '<span class="text-success">' + msg + ' Reloading…</span>';
+                setTimeout(function () { window.location.reload(); }, 1300);
+            }).catch(function () {
+                importBtn.disabled = false;
+                resultEl.innerHTML = '<span class="text-danger">Import failed.</span>';
+            });
+        });
+    })();
+
     var hasContent = layout.pods && layout.pods.length;
     if (!hasContent) {
         wrap.style.display = 'none';
         if (empty) empty.style.display = 'block';
-        var tb = document.querySelector('.map-toolbar'); if (tb) tb.style.display = 'none';
+        // keep the toolbar (Import CSV) reachable on an empty site, but hide the
+        // layout-editing buttons since there's nothing to arrange yet.
+        ['editLayoutBtn', 'autoFitBtn', 'saveLayoutBtn', 'cancelLayoutBtn'].forEach(function (id) {
+            var b = document.getElementById(id); if (b) b.style.display = 'none';
+        });
         return;
     }
 


### PR DESCRIPTION
Replaces fragile free-form pixel placement with a deterministic **grid** model, per the design we agreed: **PODs + MDCs on a grid**, **snap-to-grid drag**, **CSV create + position**.

## Stage A — grid engine
- `Location.grid_row` / `grid_col` (migration `core/0029`, hand-written).
- `_build_site_layout` is grid-aware: PODs lay out on a site grid (table layout — column widths / row heights sized to content, handles varying POD sizes), MDC tiles on a per-POD grid. Explicit cells honored; unplaced auto-fill row-major.
- **Falls back** to the existing free-form / auto-flow layout when no zone has a grid cell → existing maps unchanged until grid coords are set.

## Stage B — snap-to-grid drag
- Drag stays free; on **Save**, the editor infers a clean grid from the arrangement (cluster into rows by Y, order each row by X → row/col) for PODs and per-POD MDCs, and persists `grid_row/grid_col`. No more positional drift — Save always yields a tidy grid. `save_map_layout` accepts grid placements (preferred) or legacy pixels.

## Stage C — CSV import (create + position)
- `import_map_layout`: GET → CSV template; POST → ingest `pod,pod_row,pod_col,mdc,mdc_row,mdc_col`, **creating** any missing POD/MDC under the selected site and setting grid cells (blank `mdc` = POD only; blank coords = leave as-is). Returns a created/positioned summary + per-row issues.
- Map gains an **Import CSV** button + modal (template download, upload, result). Works on an **empty** site, so a whole site map can be built from one file.

## Verify
`manage.py check` clean; migration parity ("No changes detected"); URL/template render. **Needs dev smoke test** (full request path blocked locally by Postgres-only `core/0020`): deploy runs `migrate` (adds the two columns), then on a site: Import a CSV → PODs/MDCs created and gridded; drag + Save → snaps to grid; reload is stable.

Stacks on the map work already on `latest` (#171–#174).

🤖 Generated with [Claude Code](https://claude.com/claude-code)