### PR TITLE
feat(map): uniform POD blocks on a grid + CSV export of current layout

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -198,7 +198,10 @@ def _build_site_layout(site):
         """A POD's tiles: its direct child locations (shown if active or non-empty)
         plus per-category buckets for equipment sitting directly on the POD."""
         tiles = []
-        for child in sorted(children_by_loc.get(p.id, []), key=lambda l: natural_sort_key(l.name)):
+        for child in sorted(children_by_loc.get(p.id, []),
+                            key=lambda l: (l.grid_row if l.grid_row is not None else 9999,
+                                           l.grid_col if l.grid_col is not None else 9999,
+                                           natural_sort_key(l.name))):
             node = build_node(child)
             if child.is_active or node['count'] > 0:
                 tiles.append((child, node))
@@ -218,16 +221,17 @@ def _build_site_layout(site):
                                  'children': [], 'count': len(eqs), 'counts': counts}))
         return tiles
 
-    def assign_cells(rc_list):
-        """Place items on a grid. Each item is an (row, col) pair where both are set
-        (explicit placement) or both None (auto). Explicit cells are honored; the
-        rest auto-fill row-major into free cells. Returns (cells, ncols)."""
+    def assign_cells(rc_list, auto_cols=None):
+        """Place items on a uniform grid by (row, col). Explicit cells (both set)
+        are honored; the rest auto-fill row-major into free cells. Returns
+        (cells, ncols). auto_cols sets the width when nothing is explicitly placed."""
         n = len(rc_list)
         explicit = [(r, c) for (r, c) in rc_list if r is not None and c is not None]
+        default_cols = auto_cols or int(math.ceil(math.sqrt(max(1, n))))
         if not explicit:
-            ncols = max(1, int(math.ceil(math.sqrt(max(1, n)))))
+            ncols = max(1, default_cols)
             return [divmod(i, ncols) for i in range(n)], ncols
-        ncols = max([c for (r, c) in explicit] + [int(math.ceil(math.sqrt(max(1, n)))) - 1]) + 1
+        ncols = max([c for (r, c) in explicit] + [default_cols - 1]) + 1
         used = set(explicit)
         cells = [(r, c) if (r is not None and c is not None) else None for (r, c) in rc_list]
         cursor = 0
@@ -241,86 +245,37 @@ def _build_site_layout(site):
                     used.add((rr, cc)); cells[i] = (rr, cc); break
         return cells, ncols
 
-    # Pass 1 — per-POD tiles, grid the MDC tiles inside each POD, derive POD size.
-    pod_meta = []
-    for p in pods:
-        tiles = build_pod_tiles(p)
-        rc = [((loc.grid_row, loc.grid_col) if loc is not None else (None, None))
-              for (loc, node) in tiles]
-        cells, ncols = assign_cells(rc)
-        nrows = max((r for (r, c) in cells), default=0) + 1
-        comp_w = ncols * TILE_W + (ncols + 1) * TPAD
-        comp_h = HEADER + nrows * TILE_H + (nrows + 1) * TPAD
-        pod_meta.append({'pod': p, 'tiles': tiles, 'cells': cells,
-                         'comp_w': comp_w, 'comp_h': comp_h})
+    # Uniform POD blocks on a grid: every POD is the same fixed-size block, placed
+    # at its (grid_row, grid_col) cell (unplaced PODs auto-fill row-major). MDC tiles
+    # flow inside each block via CSS (the block scrolls if needed), so only PODs are
+    # positioned here. Empty grid cells are allowed → the map mirrors the site.
+    POD_W, POD_H = 250, 210
+    auto_cols = max(1, int((canvas_w - PAD) // (POD_W + PAD)))
+    cells, ncols = assign_cells([(p.grid_row, p.grid_col) for p in pods], auto_cols)
+    nrows = max((r for (r, c) in cells), default=0) + 1
 
-    # Pass 2 — position PODs. Grid (table: col widths / row heights sized to content)
-    # when any POD has a grid cell; otherwise legacy free-form / auto-flow wrapping.
-    pods_have_grid = any(m['pod'].grid_row is not None and m['pod'].grid_col is not None
-                         for m in pod_meta)
-    pod_pos = {}
-    if pods_have_grid:
-        cells, ncols = assign_cells([(m['pod'].grid_row, m['pod'].grid_col) for m in pod_meta])
-        nrows = max((r for (r, c) in cells), default=0) + 1
-        col_w, row_h = [0] * ncols, [0] * nrows
-        for m, (r, c) in zip(pod_meta, cells):
-            col_w[c] = max(col_w[c], m['comp_w'])
-            row_h[r] = max(row_h[r], m['comp_h'])
-        col_x, row_y = [PAD] * ncols, [PAD] * nrows
-        for c in range(1, ncols):
-            col_x[c] = col_x[c - 1] + col_w[c - 1] + PAD
-        for r in range(1, nrows):
-            row_y[r] = row_y[r - 1] + row_h[r - 1] + PAD
-        for m, (r, c) in zip(pod_meta, cells):
-            pod_pos[m['pod'].id] = (col_x[c], row_y[r], m['comp_w'], m['comp_h'])
-        canvas_h_auto = (row_y[-1] + row_h[-1] + PAD) if nrows else PAD
-    else:
-        x_cur, y_cur, rh = PAD, PAD, 0
-        for m in pod_meta:
-            p, comp_w, comp_h = m['pod'], m['comp_w'], m['comp_h']
-            if x_cur + comp_w > canvas_w and x_cur > PAD:
-                x_cur, y_cur, rh = PAD, y_cur + rh + PAD, 0
-            px = p.layout_x if p.layout_x is not None else x_cur
-            py = p.layout_y if p.layout_y is not None else y_cur
-            pod_pos[p.id] = (px, py, p.layout_width or comp_w, p.layout_height or comp_h)
-            x_cur += comp_w + PAD
-            rh = max(rh, comp_h)
-        canvas_h_auto = y_cur + rh + PAD
-
-    # Pass 3 — payloads, positioning each tile inside its POD.
     pods_payload = []
-    for m in pod_meta:
-        p = m['pod']
-        px, py, pw, ph = pod_pos[p.id]
+    for p, (r, c) in zip(pods, cells):
+        px = PAD + c * (POD_W + PAD)
+        py = PAD + r * (POD_H + PAD)
         mdcs_payload = []
-        for (loc, node), (r, c) in zip(m['tiles'], m['cells']):
-            tx = px + TPAD + c * (TILE_W + TPAD)
-            ty = py + HEADER + TPAD + r * (TILE_H + TPAD)
-            # legacy pixel override only for non-grid sites where the MDC has one
-            if not pods_have_grid and loc is not None and loc.grid_col is None and loc.layout_x is not None:
-                tx, ty = loc.layout_x, loc.layout_y
-            tw = (loc.layout_width if loc and loc.layout_width and loc.grid_col is None else TILE_W)
-            th = (loc.layout_height if loc and loc.layout_height and loc.grid_row is None else TILE_H)
+        for (loc, node) in build_pod_tiles(p):
             mdcs_payload.append({
-                # Real location -> its id (draggable/saveable); synthetic category
-                # tile -> null id (renders + expands, excluded from layout save).
                 'id': (loc.id if loc is not None else None),
                 'name': node['name'],
-                'x': round(tx, 1), 'y': round(ty, 1), 'w': round(tw, 1), 'h': round(th, 1),
                 'count': node['count'], 'counts': node['counts'],
-                # Category tiles carry flat 'equipment'; location tiles carry
-                # 'equipment_groups' (category groups) + nested 'children'.
                 'equipment': node.get('equipment', []),
                 'equipment_groups': node.get('equipment_groups', []),
                 'children': node.get('children', []),
             })
         pods_payload.append({
-            'id': p.id, 'name': p.name,
-            'x': round(px, 1), 'y': round(py, 1), 'w': round(pw, 1), 'h': round(ph, 1),
+            'id': p.id, 'name': p.name, 'row': r, 'col': c,
+            'x': round(px, 1), 'y': round(py, 1), 'w': POD_W, 'h': POD_H,
             'mdcs': mdcs_payload,
         })
 
-    canvas_h = site.layout_height or canvas_h_auto
+    canvas_w = max(canvas_w, PAD + ncols * (POD_W + PAD))
+    canvas_h = max(site.layout_height or 0, PAD + nrows * (POD_H + PAD))
     return {
         'site': {'id': site.id, 'name': site.name, 'width': canvas_w, 'height': canvas_h},
         'pods': pods_payload,
@@ -422,17 +377,46 @@ def save_map_layout(request):
 @permission_required('site_map.write')
 @require_http_methods(["GET", "POST"])
 def import_map_layout(request):
-    """CSV import for the facility-map grid. GET returns a template; POST ingests
-    a CSV (columns: pod,pod_row,pod_col,mdc,mdc_row,mdc_col) and CREATES any
-    missing POD/MDC locations under the selected site, then sets their grid cells.
-    A blank mdc places just the POD. Coordinates are 0-based; blank = leave as-is."""
+    """CSV for the facility-map grid. GET with ?site_id= exports the site's CURRENT
+    layout (so you can edit & re-upload); GET without it returns a blank template.
+    POST ingests pod,pod_row,pod_col,mdc,mdc_row,mdc_col and CREATES any missing
+    POD/MDC locations under the site, then sets their grid cells. A blank mdc places
+    just the POD. Coordinates are 0-based; blank = leave as-is."""
     if request.method == 'GET':
-        sample = ("pod,pod_row,pod_col,mdc,mdc_row,mdc_col\n"
-                  "POD 1,0,0,MDC 1,0,0\n"
-                  "POD 1,0,0,MDC 2,0,1\n"
-                  "POD 2,0,1,,,\n")
-        resp = HttpResponse(sample, content_type='text/csv')
-        resp['Content-Disposition'] = 'attachment; filename="map_layout_template.csv"'
+        out = StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['pod', 'pod_row', 'pod_col', 'mdc', 'mdc_row', 'mdc_col'])
+        site = Location.objects.filter(id=request.GET.get('site_id'), is_site=True).first()
+        if site:
+            # Effective POD cell (grid coords if set, else the auto-placed cell).
+            layout = _build_site_layout(site)
+            pod_cell = {p['id']: (p.get('row'), p.get('col')) for p in layout.get('pods', [])}
+            pods = sorted(Location.objects.filter(parent_location=site),
+                          key=lambda l: (l.grid_row if l.grid_row is not None else 9999,
+                                         l.grid_col if l.grid_col is not None else 9999,
+                                         natural_sort_key(l.name)))
+            for pod in pods:
+                pr, pc = pod_cell.get(pod.id, (pod.grid_row, pod.grid_col))
+                mdcs = sorted(Location.objects.filter(parent_location=pod),
+                              key=lambda l: (l.grid_row if l.grid_row is not None else 9999,
+                                             l.grid_col if l.grid_col is not None else 9999,
+                                             natural_sort_key(l.name)))
+                if mdcs:
+                    for mdc in mdcs:
+                        writer.writerow([pod.name, pr, pc, mdc.name,
+                                         mdc.grid_row if mdc.grid_row is not None else '',
+                                         mdc.grid_col if mdc.grid_col is not None else ''])
+                else:
+                    writer.writerow([pod.name, pr, pc, '', '', ''])
+            fname = f'map_layout_{site.name}.csv'.replace(' ', '_')
+        else:
+            # No site -> blank template with a couple of example rows.
+            writer.writerow(['POD 1', 0, 0, 'MDC 1', '', ''])
+            writer.writerow(['POD 1', 0, 0, 'MDC 2', '', ''])
+            writer.writerow(['POD 2', 0, 1, '', '', ''])
+            fname = 'map_layout_template.csv'
+        resp = HttpResponse(out.getvalue(), content_type='text/csv')
+        resp['Content-Disposition'] = f'attachment; filename="{fname}"'
         return resp
 
     site = get_object_or_404(Location, id=request.POST.get('site_id'), is_site=True)

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -35,31 +35,34 @@
 .h-ok { background:#276749; border-color:#48bb78; }
 .h-idle { background:#3a4456; border-color:#718096; }
 
+/* Uniform POD block: fixed-size card; header + scrollable body of MDC tiles. */
 .pod-zone { position: absolute; border: 1px solid #5a6987; border-radius: 8px;
-    background: rgba(45,55,72,0.45); box-sizing: border-box; }
-.pod-header { position: absolute; top: 0; left: 0; right: 0; height: 26px; padding: 4px 10px;
-    font-size: 12px; font-weight: 700; color: #e2e8f0; border-bottom: 1px solid #4a5568;
+    background: rgba(45,55,72,0.45); box-sizing: border-box;
+    display: flex; flex-direction: column; overflow: hidden; }
+.pod-header { flex: 0 0 auto; padding: 5px 10px; font-size: 12px; font-weight: 700;
+    color: #e2e8f0; border-bottom: 1px solid #4a5568;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 #canvasWrap.editing .pod-header { cursor: move; }
+.pod-body { flex: 1 1 auto; overflow: auto; padding: 6px; display: flex;
+    flex-wrap: wrap; gap: 6px; align-content: flex-start; }
 
-.mdc-tile { position: absolute; border: 1px solid #5a6987; border-radius: 6px;
-    background: #222c40; box-sizing: border-box; }
+/* MDC tiles flow inside the block; expanding one takes the full block width. */
+.mdc-tile { position: relative; border: 1px solid #5a6987; border-radius: 6px;
+    background: #222c40; box-sizing: border-box; width: 108px; align-self: flex-start; }
+.mdc-tile.expanded { width: 100%; }
 .mdc-tile-header { padding: 4px 8px; font-size: 11px; font-weight: 600; color: #e2e8f0;
     display: flex; justify-content: space-between; align-items: center; gap: 6px; cursor: pointer;
     white-space: nowrap; overflow: hidden; }
 .mdc-tile-header:hover { background: #2a3550; border-radius: 6px 6px 0 0; }
-#canvasWrap.editing .mdc-tile-header { cursor: move; }
 .mdc-tile-name { overflow: hidden; text-overflow: ellipsis; }
 .mdc-count { color: #a0aec0; font-weight: 400; font-size: 10px; white-space: nowrap; }
 .mdc-summary { display: flex; gap: 6px; padding: 0 8px 5px; flex-wrap: wrap; font-size: 10px; }
 .mdc-summary .dot { font-weight: 700; }
 .mdc-caret { color: #718096; font-size: 9px; margin-left: 2px; }
 
-.mdc-body { display: none; position: absolute; left: -1px; top: 100%; min-width: calc(100% + 2px);
-    max-width: 320px; max-height: 220px; overflow: auto; background: #1a2238;
-    border: 1px solid #4299e1; border-top: none; border-radius: 0 0 6px 6px; padding: 6px;
-    flex-wrap: wrap; gap: 4px; z-index: 25; }
-.mdc-tile.expanded { z-index: 30; }
+.mdc-body { display: none; overflow: auto; max-height: 240px; background: #1a2238;
+    border-top: 1px solid #4299e1; border-radius: 0 0 6px 6px; padding: 6px;
+    flex-wrap: wrap; gap: 4px; }
 .mdc-tile.expanded .mdc-body { display: flex; }
 .mdc-tile.expanded .mdc-caret { transform: rotate(90deg); }
 .mdc-empty { color: #718096; font-size: 11px; padding: 2px 4px; }
@@ -127,8 +130,8 @@
                   Columns: <code>pod, pod_row, pod_col, mdc, mdc_row, mdc_col</code> (0-based; blank
                   <code>mdc</code> places just the POD). Missing locations are created under this site.
                 </p>
-                <a href="{% url 'core:import_map_layout' %}" class="btn btn-link btn-sm px-0">
-                  <i class="fas fa-download me-1"></i> Download template
+                <a href="{% url 'core:import_map_layout' %}?site_id={{ selected_site.id }}" class="btn btn-link btn-sm px-0">
+                  <i class="fas fa-download me-1"></i> Download current layout
                 </a>
                 <input type="file" id="importCsvFile" accept=".csv,text/csv" class="form-control mt-2">
                 <div id="importCsvResult" class="mt-2" style="font-size:.86rem;"></div>
@@ -320,30 +323,24 @@
         ph.className = 'pod-header';
         ph.textContent = pod.name;
         ph.addEventListener('pointerdown', function (e) {
-            if (!editing) return;
-            beginDrag(e, [zone].concat(tilesByPod[pod.id] || []));
+            if (editing) beginDrag(e, [zone]);  // moving the block moves its tiles (they're children)
         });
         zone.appendChild(ph);
-        addResizeHandle(zone);
-        canvas.appendChild(zone);
 
-        tilesByPod[pod.id] = [];
+        var pbody = document.createElement('div');
+        pbody.className = 'pod-body';
         (pod.mdcs || []).forEach(function (mdc) {
             var tile = document.createElement('div');
             tile.className = 'mdc-tile';
             if (mdc.id != null) tile.dataset.id = mdc.id;
             tile.dataset.podId = pod.id;
-            tile.style.left = mdc.x + 'px'; tile.style.top = mdc.y + 'px';
-            tile.style.width = mdc.w + 'px'; tile.style.height = mdc.h + 'px';
 
             var hdr = document.createElement('div');
             hdr.className = 'mdc-tile-header';
             hdr.innerHTML = '<span class="mdc-tile-name">' + escapeHtml(mdc.name) +
                 '</span><span class="mdc-count">' + mdc.count + ' <span class="mdc-caret">&#9656;</span></span>';
-            hdr.addEventListener('pointerdown', function (e) {
-                if (editing) { beginDrag(e, [tile]); }
-            });
-            hdr.addEventListener('click', function () {
+            hdr.addEventListener('click', function (ev) {
+                ev.stopPropagation();
                 if (!editing) tile.classList.toggle('expanded');
             });
             tile.appendChild(hdr);
@@ -366,9 +363,10 @@
             fillNodeBody(body, mdc);
             tile.appendChild(body);
 
-            canvas.appendChild(tile);
-            tilesByPod[pod.id].push(tile);
+            pbody.appendChild(tile);
         });
+        zone.appendChild(pbody);
+        canvas.appendChild(zone);
     });
 
     function escapeHtml(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
@@ -441,34 +439,18 @@
             }
         }
 
-        // Auto-fit: flow PODs left-to-right (wrapping at canvas width), and re-grid
-        // each POD's MDC tiles into a tidy grid inside it. Mirrors the server's
-        // default auto-layout (_build_site_layout) so the result matches a fresh map.
+        // Auto-fit: re-pack the uniform POD blocks into a tidy grid (row-major,
+        // wrapping at the canvas width) in their current DOM order.
         function autoFit() {
-            var PAD = 24, HEADER = 28, TILE_W = 156, TILE_H = 58, TPAD = 10;
+            var PAD = 24, POD_W = 250, POD_H = 210;
             var canvasW = (layout.site && layout.site.width) || canvas.clientWidth || 1280;
-            var xCur = PAD, yCur = PAD, rowH = 0;
-            Array.prototype.forEach.call(canvas.querySelectorAll('.pod-zone'), function (zone) {
-                var tiles = tilesByPod[zone.dataset.id] || [];
-                var n = Math.max(1, tiles.length);
-                var cols = Math.max(1, Math.ceil(Math.sqrt(n)));
-                var rows = Math.ceil(n / cols);
-                var compW = cols * TILE_W + (cols + 1) * TPAD;
-                var compH = HEADER + rows * TILE_H + (rows + 1) * TPAD;
-                // wrap to the next row when this POD would overflow the canvas width
-                if (xCur + compW > canvasW && xCur > PAD) { xCur = PAD; yCur += rowH + PAD; rowH = 0; }
-                var pl = xCur, pt = yCur;
-                zone.style.left = pl + 'px'; zone.style.top = pt + 'px';
-                zone.style.width = compW + 'px'; zone.style.height = compH + 'px';
-                tiles.forEach(function (tile, i) {
-                    var r = Math.floor(i / cols), c = i % cols;
-                    tile.style.left = (pl + TPAD + c * (TILE_W + TPAD)) + 'px';
-                    tile.style.top = (pt + HEADER + TPAD + r * (TILE_H + TPAD)) + 'px';
-                    tile.style.width = TILE_W + 'px';
-                    tile.style.height = TILE_H + 'px';
-                });
-                xCur += compW + PAD;
-                rowH = Math.max(rowH, compH);
+            var cols = Math.max(1, Math.floor((canvasW - PAD) / (POD_W + PAD)));
+            Array.prototype.forEach.call(canvas.querySelectorAll('.pod-zone'), function (zone, i) {
+                var r = Math.floor(i / cols), c = i % cols;
+                zone.style.left = (PAD + c * (POD_W + PAD)) + 'px';
+                zone.style.top = (PAD + r * (POD_H + PAD)) + 'px';
+                zone.style.width = POD_W + 'px';
+                zone.style.height = POD_H + 'px';
             });
             dirty = true;
         }
@@ -515,18 +497,7 @@
             Object.keys(podGrid).forEach(function (id) {
                 zones.push({ id: parseInt(id, 10), grid_row: podGrid[id].row, grid_col: podGrid[id].col });
             });
-            // MDC tiles -> per-POD grid cells
-            var byPod = {};
-            Array.prototype.forEach.call(canvas.querySelectorAll('.mdc-tile[data-id]'), function (el) {
-                var pid = el.dataset.podId || '_';
-                (byPod[pid] = byPod[pid] || []).push({ id: parseInt(el.dataset.id, 10), x: px(el, 'left'), y: px(el, 'top') });
-            });
-            Object.keys(byPod).forEach(function (pid) {
-                var g = inferGrid(byPod[pid]);
-                Object.keys(g).forEach(function (id) {
-                    zones.push({ id: parseInt(id, 10), grid_row: g[id].row, grid_col: g[id].col });
-                });
-            });
+            // (MDC tiles flow inside their POD block — no positions to save.)
             var token = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value;
             saveBtn.disabled = true; saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Saving...';
             fetch(saveUrl, {


### PR DESCRIPTION
Per feedback on the grid work: switch to **uniform blocks** and make the CSV reflect the **current layout**.

## Uniform POD blocks
- Every POD is the same fixed-size block, placed at its `(grid_row, grid_col)` cell. Unplaced PODs auto-fill row-major; **empty cells allowed** so the map mirrors the physical site (gaps where nothing exists).
- **MDC tiles flow inside** each block (CSS); the block scrolls if there are many. Click an MDC to expand its category / sub-location tree **inline**.
- Drag moves whole blocks; **Save** snaps blocks to grid cells; **Auto-fit** re-packs blocks into a tidy grid. (No more per-tile dragging/resizing.)

## CSV = current layout
- `Import CSV` modal's download is now **"Download current layout"** (`?site_id=`) — exports the site's existing PODs/MDCs with their effective grid cells, so you edit & re-upload instead of starting from a blank template. (No site → blank template still available.)

## Why it looked unchanged before
The grid only activates once zones have coordinates; with none set it fell back to auto-flow (looked the same). Now PODs always render as a uniform block grid, and snap/CSV set the coordinates.

## Verify
`manage.py check` clean; template renders. Dev eyeball: blocks should be uniform; Edit → drag a block → Save snaps to grid; Import CSV → Download current layout → edit rows → re-upload repositions/creates.

Stacks on #171–#175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)