### PR TITLE
fix(users): readable API token field (contrast)

### DIFF
--- a/templates/core/user_management.html
+++ b/templates/core/user_management.html
@@ -318,7 +318,7 @@
         <div id="createAgentResult" style="display:none;">
           <div class="alert alert-success mb-2"><i class="fas fa-check-circle me-1"></i> Agent created. Copy the token now:</div>
           <div class="input-group">
-            <input type="text" class="form-control text-monospace" id="newAgentToken" readonly>
+            <input type="text" class="form-control agent-token" id="newAgentToken" readonly>
             <button class="btn btn-outline-primary" type="button" onclick="copyAgentToken('newAgentToken', this)">
               <i class="fas fa-copy"></i> Copy
             </button>
@@ -339,6 +339,15 @@
 
 {% block extra_css %}
 <style>
+/* API token field — force readable contrast in the dark theme */
+.agent-token {
+    background-color: #0d1117 !important;
+    color: #e2e8f0 !important;
+    border-color: #4a5568 !important;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: .5px;
+}
+.agent-token::placeholder { color: #4a5568 !important; }
 .avatar-circle {
     width: 40px;
     height: 40px;
@@ -440,7 +449,7 @@ function loadAgents() {
                 var tid = 'tok-' + a.id;
                 var tokenCell = a.token
                     ? '<div class="input-group input-group-sm" style="max-width:340px;">'
-                      + '<input type="password" class="form-control text-monospace" id="' + tid + '" value="' + escapeHtml(a.token) + '" readonly>'
+                      + '<input type="password" class="form-control agent-token" id="' + tid + '" value="' + escapeHtml(a.token) + '" readonly>'
                       + '<button class="btn btn-outline-secondary" type="button" title="Show/hide" onclick="toggleToken(\'' + tid + '\', this)"><i class="fas fa-eye"></i></button>'
                       + '<button class="btn btn-outline-primary" type="button" title="Copy" onclick="copyAgentToken(\'' + tid + '\', this)"><i class="fas fa-copy"></i></button>'
                       + '</div>'


### PR DESCRIPTION
The API token input had near-invisible text in the dark theme. Adds an explicit `.agent-token` style (dark background, light monospace text) on the table token field and the new-agent modal field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)