### PR TITLE
feat(map): sortable drag — blocks shift aside instead of overlapping

### DIFF
--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -38,7 +38,9 @@
 /* Uniform POD block: fixed-size card; header + scrollable body of MDC tiles. */
 .pod-zone { position: absolute; border: 1px solid #5a6987; border-radius: 8px;
     background: rgba(45,55,72,0.45); box-sizing: border-box;
-    display: flex; flex-direction: column; overflow: hidden; }
+    display: flex; flex-direction: column; overflow: hidden;
+    transition: left .15s ease, top .15s ease; }
+.pod-zone.dragging { transition: none; }  /* dragged block follows the pointer */
 .pod-header { flex: 0 0 auto; padding: 5px 10px; font-size: 12px; font-weight: 700;
     color: #e2e8f0; border-bottom: 1px solid #4a5568;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -371,24 +373,54 @@
 
     function escapeHtml(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
-    // ----- drag (snaps to the POD grid live; account for canvas scale) -----
+    // ----- drag: sortable grid. Dragging a block over a cell shifts the other
+    //       blocks aside (animated) to open that slot, instead of overlapping. -----
     var GRID_PAD = 24, GRID_SX = 250 + 24, GRID_SY = 210 + 24;  // POD_W+PAD, POD_H+PAD
-    function snap(v, stride) {
-        return GRID_PAD + Math.max(0, Math.round((v - GRID_PAD) / stride)) * stride;
+    function gridCols() {
+        return Math.max(1, Math.floor(((layout.site.width || 1280) - GRID_PAD) / GRID_SX));
+    }
+    function podOrder() {  // current PODs in visual (row-major) order
+        var zones = Array.prototype.slice.call(canvas.querySelectorAll('.pod-zone'));
+        zones.sort(function (a, b) {
+            var ay = px(a, 'top'), by = px(b, 'top');
+            if (Math.abs(ay - by) > GRID_SY / 2) return ay - by;
+            return px(a, 'left') - px(b, 'left');
+        });
+        return zones;
+    }
+    function layoutOrder(order, skipEl) {  // place each block at its packed cell
+        var cols = gridCols();
+        order.forEach(function (el, i) {
+            if (el === skipEl) return;
+            el.style.left = (GRID_PAD + (i % cols) * GRID_SX) + 'px';
+            el.style.top = (GRID_PAD + Math.floor(i / cols) * GRID_SY) + 'px';
+        });
     }
     function beginDrag(e, els) {
         e.preventDefault();
+        var el = els[0];
+        var order = podOrder();
+        var idx = order.indexOf(el);
+        var cols = gridCols();
         var sx = e.clientX, sy = e.clientY;
-        var origins = els.map(function (el) { el.classList.add('dragging'); return { el: el, l: px(el, 'left'), t: px(el, 'top') }; });
+        var l0 = px(el, 'left'), t0 = px(el, 'top');
+        el.classList.add('dragging');
         function move(ev) {
-            var dx = (ev.clientX - sx) / scale, dy = (ev.clientY - sy) / scale;
-            origins.forEach(function (o) {
-                o.el.style.left = snap(o.l + dx, GRID_SX) + 'px';
-                o.el.style.top = snap(o.t + dy, GRID_SY) + 'px';
-            });
+            var nx = l0 + (ev.clientX - sx) / scale, ny = t0 + (ev.clientY - sy) / scale;
+            el.style.left = nx + 'px'; el.style.top = ny + 'px';   // dragged follows pointer
+            var c = Math.min(cols - 1, Math.max(0, Math.round((nx - GRID_PAD) / GRID_SX)));
+            var r = Math.max(0, Math.round((ny - GRID_PAD) / GRID_SY));
+            var ti = Math.min(order.length - 1, Math.max(0, r * cols + c));
+            if (ti !== idx) {                       // reorder + shift others aside
+                order.splice(idx, 1);
+                order.splice(ti, 0, el);
+                idx = ti;
+                layoutOrder(order, el);
+            }
         }
         function up() {
-            origins.forEach(function (o) { o.el.classList.remove('dragging'); });
+            el.classList.remove('dragging');
+            layoutOrder(order, null);               // drop into the open slot
             document.removeEventListener('pointermove', move);
             document.removeEventListener('pointerup', up);
             dirty = true;


### PR DESCRIPTION
Dragging a POD over another's cell now **reorders** and **shifts the other blocks aside** (animated) to open that slot — no more stacking on top or having to overshoot. Dragged block follows the pointer; others reflow live; on drop it lands in the open slot. Save persists the new row/col order.

**Trade-off:** drag-reorder packs blocks row-major (no gaps). For intentional empty cells / exact placement, use the CSV import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)