### PR TITLE
fix(auth): keep users logged in across redeploys (cached_db sessions)

### DIFF
--- a/maintenance_dashboard/settings.py
+++ b/maintenance_dashboard/settings.py
@@ -487,7 +487,10 @@ def get_cache_config():
                     'KEY_PREFIX': 'maintenance_dashboard',
                     'TIMEOUT': 300,  # 5 minutes default timeout
                 }
-            }, 'django.contrib.sessions.backends.cache'
+            # cached_db (NOT cache): sessions are persisted in Postgres and cached
+            # in Redis for speed. A redeploy that restarts Redis wipes the cache but
+            # sessions survive in the DB, so users stay logged in across deploys.
+            }, 'django.contrib.sessions.backends.cached_db'
         except Exception as e:
             import logging
             logger = logging.getLogger(__name__)


### PR DESCRIPTION
**Symptom:** every redeploy forces a re-login.

**Cause:** when Redis is available, `SESSION_ENGINE` was `...backends.cache` — sessions lived *only* in the Redis cache (db 1), which has no persistence. A full-stack redeploy restarts the Redis container → cache wiped → all sessions invalid.

**Fix:** use `...backends.cached_db` — sessions are persisted in Postgres (`django_session`) and cached in Redis for speed. Redeploys (and Redis restarts) no longer log everyone out. No migration needed (`django_session` already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)