### PR TITLE
feat(map): right-click menu to add a location / sub-location

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('map/', views.map_view, name='map_view'),
     path('map/layout/save/', views.save_map_layout, name='save_map_layout'),
     path('map/layout/import/', views.import_map_layout, name='import_map_layout'),
+    path('map/location/add/', views.add_map_location, name='add_map_location'),
     path('locations/settings/', views.locations_settings, name='locations_settings'),
     path('equipment-items/settings/', views.equipment_items_settings, name='equipment_items_settings'),
     path('equipment-conditional-fields/settings/', views.equipment_conditional_fields_settings, name='equipment_conditional_fields_settings'),

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -481,6 +481,52 @@ def import_map_layout(request):
                          'errors': errors[:50]})
 
 
+@permission_required('site_map.write')
+@require_POST
+def add_map_location(request):
+    """Create a location/sub-location from the map's right-click menu. JSON:
+    {site_id, name, parent_id?, grid_row?, grid_col?}. parent_id defaults to the
+    site (a new POD); otherwise it's a child under that POD/MDC. Optional grid
+    cell positions a new POD."""
+    from core.utils import get_all_descendant_location_ids
+    try:
+        data = json.loads(request.body or b'{}')
+    except (ValueError, TypeError):
+        return JsonResponse({'success': False, 'error': 'Invalid JSON'}, status=400)
+
+    name = (data.get('name') or '').strip()
+    if not name:
+        return JsonResponse({'success': False, 'error': 'A name is required.'}, status=400)
+    site = get_object_or_404(Location, id=data.get('site_id'), is_site=True)
+
+    parent_id = data.get('parent_id')
+    if parent_id:
+        allowed = set(get_all_descendant_location_ids(site, include_inactive=True)) | {site.id}
+        try:
+            parent_id = int(parent_id)
+        except (TypeError, ValueError):
+            return JsonResponse({'success': False, 'error': 'Invalid parent.'}, status=400)
+        if parent_id not in allowed:
+            return JsonResponse({'success': False, 'error': 'Parent is not part of this site.'}, status=400)
+        parent = get_object_or_404(Location, id=parent_id)
+    else:
+        parent = site
+
+    if Location.objects.filter(name=name, parent_location=parent).exists():
+        return JsonResponse({'success': False, 'error': f'"{name}" already exists here.'}, status=400)
+
+    def gi(v):
+        try:
+            return max(0, int(v))
+        except (TypeError, ValueError):
+            return None
+
+    loc = Location.objects.create(
+        name=name, parent_location=parent, is_site=False, is_active=True,
+        grid_row=gi(data.get('grid_row')), grid_col=gi(data.get('grid_col')))
+    return JsonResponse({'success': True, 'id': loc.id, 'name': loc.name})
+
+
 @login_required
 @user_passes_test(is_staff_or_superuser)
 def locations_settings(request):
@@ -1319,4 +1365,4 @@ def bulk_locations_view(request):
     return render(request, 'core/bulk_locations.html', context)
 
 
-__all__ = ["map_view", "save_map_layout", "import_map_layout", "locations_settings", "locations_api", "location_detail_api", "add_location", "edit_location", "export_sites_csv", "import_sites_csv", "delete_location", "export_locations_csv", "import_locations_csv", "bulk_edit_locations", "bulk_locations_view"]
+__all__ = ["map_view", "save_map_layout", "import_map_layout", "add_map_location", "locations_settings", "locations_api", "location_detail_api", "add_location", "edit_location", "export_sites_csv", "import_sites_csv", "delete_location", "export_locations_csv", "import_locations_csv", "bulk_edit_locations", "bulk_locations_view"]

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -98,6 +98,11 @@
 .resize-handle { position:absolute; right:-3px; bottom:-3px; width:14px; height:14px; cursor:se-resize;
     display:none; background:#fff; border:2px solid #4299e1; border-radius:3px; z-index:6; }
 #canvasWrap.editing .resize-handle { display:block; }
+.ctx-menu { position: fixed; z-index: 1000; background: #222c40; border: 1px solid #4a5568;
+    border-radius: 6px; padding: 4px; min-width: 210px; box-shadow: 0 6px 20px rgba(0,0,0,.45); }
+.ctx-menu button { display: block; width: 100%; text-align: left; background: none; border: none;
+    color: #e2e8f0; padding: 7px 10px; font-size: 13px; border-radius: 4px; cursor: pointer; white-space: nowrap; }
+.ctx-menu button:hover { background: #2a3550; }
 .dragging { opacity:.85; z-index:40 !important; }
 </style>
 {% endblock %}
@@ -196,6 +201,7 @@
         <h5 class="text-muted">No zones to map for this site</h5>
         <p>Once this site has PODs/MDCs and equipment, they'll appear here.</p>
     </div>
+    {% if can_edit_map %}<div id="ctxMenu" class="ctx-menu" style="display:none;"></div>{% endif %}
 {% endif %}
 {% endblock %}
 
@@ -588,6 +594,61 @@
         window.addEventListener('beforeunload', function (e) {
             if (editing && dirty) { e.preventDefault(); e.returnValue = ''; }
         });
+
+        // ----- right-click menu: add a location / sub-location where you click -----
+        var ctxMenu = document.getElementById('ctxMenu');
+        if (ctxMenu) {
+            function hideMenu() { ctxMenu.style.display = 'none'; ctxMenu.innerHTML = ''; }
+            document.addEventListener('click', hideMenu);
+            document.addEventListener('scroll', hideMenu, true);
+            window.addEventListener('resize', hideMenu);
+            canvas.addEventListener('contextmenu', function (ev) {
+                ev.preventDefault();
+                var tile = ev.target.closest && ev.target.closest('.mdc-tile[data-id]');
+                var pod = ev.target.closest && ev.target.closest('.pod-zone[data-id]');
+                var opts = [];
+                if (tile) {
+                    var tn = (tile.querySelector('.mdc-tile-name') || {}).textContent || 'location';
+                    opts.push({ label: '➕ Add sub-location to "' + tn.trim() + '"', parent: tile.dataset.id });
+                }
+                if (pod) {
+                    var pn = (pod.querySelector('.pod-header') || {}).textContent || 'POD';
+                    opts.push({ label: '➕ Add sub-location to "' + pn.trim() + '"', parent: pod.dataset.id });
+                }
+                if (!pod) {  // empty cell -> new POD at that cell
+                    var rect = canvas.getBoundingClientRect();
+                    var c = Math.max(0, Math.floor((((ev.clientX - rect.left) / scale) - GRID_PAD) / GRID_SX));
+                    var r = Math.max(0, Math.floor((((ev.clientY - rect.top) / scale) - GRID_PAD) / GRID_SY));
+                    opts.push({ label: '➕ Add POD here', parent: null, r: r, c: c });
+                }
+                ctxMenu.innerHTML = '';
+                opts.forEach(function (o) {
+                    var b = document.createElement('button');
+                    b.textContent = o.label;
+                    b.addEventListener('click', function (e) { e.stopPropagation(); hideMenu(); addLocation(o); });
+                    ctxMenu.appendChild(b);
+                });
+                ctxMenu.style.left = ev.clientX + 'px';
+                ctxMenu.style.top = ev.clientY + 'px';
+                ctxMenu.style.display = 'block';
+            });
+            function addLocation(o) {
+                var name = (prompt(o.parent ? 'Name of the new sub-location:' : 'Name of the new POD:') || '').trim();
+                if (!name) return;
+                var token = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value;
+                var body = { site_id: layout.site.id, name: name, parent_id: o.parent };
+                if (o.r != null) { body.grid_row = o.r; body.grid_col = o.c; }
+                fetch("{% url 'core:add_map_location' %}", {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': token, 'X-Requested-With': 'XMLHttpRequest' },
+                    credentials: 'same-origin', body: JSON.stringify(body)
+                }).then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
+                  .then(function (res) {
+                      if (!res.ok || !res.d.success) { alert((res.d && res.d.error) || 'Could not add location.'); return; }
+                      window.location.reload();
+                  }).catch(function () { alert('Request failed.'); });
+            }
+        }
     }
 })();
 </script>


### PR DESCRIPTION
Right-click anywhere on the map to add a location where you click:
- **empty cell** → "Add POD here" (creates a POD at that grid cell)
- **a POD block** → "Add sub-location to <POD>"
- **an MDC / location tile** → "Add sub-location to <tile>" (and an option for its POD)

Backend `add_map_location` (POST `{site_id, name, parent_id?, grid_row?, grid_col?}`) creates the Location under the site / POD / MDC (validated as part of the site) and positions new PODs at the clicked cell. Gated by `site_map.write`. Prompts for a name, then reloads. Route `map/location/add/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)