### PR TITLE
fix: bug bonanza wave 1 — broken endpoints, RBAC gaps, branding lookup

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -758,6 +758,14 @@ class BrandingSettings(models.Model):
             BrandingSettings.objects.exclude(pk=self.pk).update(is_active=False)
         super().save(*args, **kwargs)
 
+    @classmethod
+    def get_active(cls):
+        """Return the active branding settings, creating defaults if none exist."""
+        obj = cls.objects.filter(is_active=True).first()
+        if obj is None:
+            obj = cls.objects.create(is_active=True)
+        return obj
+
 
 class DashboardSettings(models.Model):
     """Dashboard/Overview page configuration settings"""

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -915,7 +915,7 @@ def import_sites_csv(request):
     try:
         # Read CSV file
         file_data = csv_file.read().decode('utf-8')
-        csv_data = csv.reader(io.StringIO(file_data))
+        csv_data = csv.reader(StringIO(file_data))
         
         # Skip header row
         header = next(csv_data)
@@ -1086,7 +1086,7 @@ def import_locations_csv(request):
     try:
         # Read CSV file
         file_data = csv_file.read().decode('utf-8')
-        csv_data = csv.reader(io.StringIO(file_data))
+        csv_data = csv.reader(StringIO(file_data))
         
         # Skip header row
         header = next(csv_data)
@@ -1306,7 +1306,7 @@ def bulk_edit_locations(request):
                             continue
                         
                         # Check if location has equipment
-                        if hasattr(location, 'equipment_set') and location.equipment_set.exists():
+                        if location.equipment.exists():
                             errors.append(f'Cannot delete "{location.name}" - has associated equipment')
                             continue
                         

--- a/equipment/views.py
+++ b/equipment/views.py
@@ -2271,7 +2271,7 @@ def field_configuration_settings(request):
     return render(request, 'equipment/field_configuration_settings.html', context)
 
 
-@login_required
+@permission_required('equipment.edit')
 @require_http_methods(["POST"])
 def create_connection(request):
     """Create a new equipment connection."""
@@ -2347,7 +2347,7 @@ def create_connection(request):
         }, status=500)
 
 
-@login_required
+@permission_required('equipment.delete')
 @require_http_methods(["DELETE"])
 def delete_connection(request, connection_id):
     """Delete an equipment connection."""

--- a/events/views.py
+++ b/events/views.py
@@ -920,6 +920,7 @@ def get_event_color(event_type, priority):
         return base_color + '99'  # 60% opacity
 
 
+@login_required
 @require_http_methods(["GET"])
 def get_event(request, event_id):
     """API endpoint to get a specific event."""

--- a/maintenance/views/activities.py
+++ b/maintenance/views/activities.py
@@ -1367,7 +1367,7 @@ def create_activity_api(request):
         }, status=500)
 
 
-@login_required
+@permission_required('maintenance.edit')
 def upload_activity_document(request, activity_id):
     """Upload a document to a maintenance activity."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)
@@ -1415,7 +1415,7 @@ def upload_activity_document(request, activity_id):
     return render(request, 'maintenance/upload_document.html', context)
 
 
-@login_required
+@permission_required('maintenance.edit')
 def change_activity_status(request, activity_id):
     """Change activity status without editing the entire activity."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)
@@ -1482,7 +1482,7 @@ def change_activity_status(request, activity_id):
     return render(request, 'maintenance/change_status.html', context)
 
 
-@login_required
+@permission_required('maintenance.edit')
 def attach_related_activity(request, activity_id):
     """Attach a related activity to the current activity."""
     activity = get_object_or_404(MaintenanceActivity, id=activity_id)

--- a/maintenance/views/schedules.py
+++ b/maintenance/views/schedules.py
@@ -544,7 +544,7 @@ def schedule_override_detail(request, override_id):
     return render(request, 'maintenance/schedule_override_detail.html', context)
 
 
-@login_required
+@permission_required('maintenance.create')
 def apply_schedules_to_equipment(request, equipment_id):
     """Apply category and global schedules to specific equipment."""
     equipment = get_object_or_404(Equipment, id=equipment_id)

--- a/templates/core/equipment_conditional_fields_settings.html
+++ b/templates/core/equipment_conditional_fields_settings.html
@@ -261,7 +261,7 @@ $(document).ready(function() {
          
          if (sourceCategoryId) {
              // Fetch fields for the selected source category
-             $.get(`/core/api/categories/${sourceCategoryId}/fields/`, function(data) {
+             $.get(`/api/categories/${sourceCategoryId}/fields/`, function(data) {
                  fieldSelect.empty();
                  
                  if (data.fields && data.fields.length > 0) {

--- a/templates/events/equipment_events.html
+++ b/templates/events/equipment_events.html
@@ -18,7 +18,7 @@
             <a href="{% url 'equipment:equipment_detail' equipment.id %}" class="btn btn-outline-secondary">
                 <i class="fas fa-cog me-1"></i>Equipment Details
             </a>
-            <a href="{% url 'events:calendar' %}" class="btn btn-outline-secondary">
+            <a href="{% url 'events:calendar_view' %}" class="btn btn-outline-secondary">
                 <i class="fas fa-calendar me-1"></i>Calendar
             </a>
         </div>


### PR DESCRIPTION
Audit-driven fixes (wave 1 of the bonanza). All independent, verifiable.

**HIGH**
- **CSV import (sites + locations) was completely broken** — `io.StringIO` used but only `StringIO` imported → `NameError` swallowed as "Error reading CSV". → `StringIO`.
- **`/core/` path 404** in `equipment_conditional_fields_settings.html` (core.urls is at root) → `/api/categories/<id>/fields/`. Conditional-field dropdown works now.
- **`{% url 'events:calendar' %}` → 500** (no such name) → `events:calendar_view`.
- **Missing `BrandingSettings.get_active()`** — `dashboard.py` called it (swallowed by `except`), so configured **maintenance status colors never reached the overview**. Added the classmethod.

**MEDIUM (security/correctness)**
- **RBAC gaps** — mutating views were `@login_required` only (a viewer could write): `create_connection`/`delete_connection`, `apply_schedules_to_equipment`, `upload_activity_document`/`change_activity_status`/`attach_related_activity` → proper `@permission_required`.
- **`get_event` API had no auth** → `@login_required`.
- **bulk-delete location guard** used the wrong related-name (`equipment_set`, never exists) → `location.equipment.exists()` (friendly message instead of raw ProtectedError).

`manage.py check` clean; URLs/templates verified. More waves coming (Bootstrap-4 modal fixes, missing templates, migration commit, branding overhaul).

🤖 Generated with [Claude Code](https://claude.com/claude-code)