### PR TITLE
fix(ui): bug bonanza wave 2 — Bootstrap 4 modal/attr fixes

### DIFF
--- a/templates/core/custom_fields_management.html
+++ b/templates/core/custom_fields_management.html
@@ -33,7 +33,7 @@
     {% for message in messages %}
     <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
         {{ message }}
-        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     </div>
     {% endfor %}
 </div>

--- a/templates/core/dashboard_settings.html
+++ b/templates/core/dashboard_settings.html
@@ -89,8 +89,8 @@
                             const helpIcon = document.createElement('i');
                             helpIcon.className = 'fas fa-question-circle template-help-icon';
                             helpIcon.title = 'Click for available variables';
-                            helpIcon.setAttribute('data-bs-toggle', 'tooltip');
-                            helpIcon.setAttribute('data-bs-placement', 'right');
+                            helpIcon.setAttribute('data-toggle', 'tooltip');
+                            helpIcon.setAttribute('data-placement', 'right');
                             
                             const tooltip = document.createElement('div');
                             tooltip.className = 'template-tooltip';

--- a/templates/core/debug.html
+++ b/templates/core/debug.html
@@ -253,7 +253,7 @@
         <div class="modal-content bg-dark text-light">
             <div class="modal-header border-secondary">
                 <h5 class="modal-title"><i class="fas fa-database me-2"></i>Generate Demo Data</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-info">
@@ -266,7 +266,7 @@
                 </div>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-primary" onclick="generateDemoData()">
                     <i class="fas fa-play me-1"></i>Generate
                 </button>
@@ -283,7 +283,7 @@
                 <h5 class="modal-title text-warning">
                     <i class="fas fa-calendar-times me-2"></i>Clear Maintenance Activities
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-warning">
@@ -314,7 +314,7 @@
                 </div>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-warning" onclick="clearMaintenance()">
                     <i class="fas fa-calendar-times me-1"></i>Clear Maintenance
                 </button>
@@ -331,7 +331,7 @@
                 <h5 class="modal-title text-danger">
                     <i class="fas fa-exclamation-triangle me-2"></i>Clear Database
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-danger">
@@ -351,7 +351,7 @@
                 </div>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" id="confirm-clear" disabled onclick="clearDatabase()">
                     <i class="fas fa-trash-alt me-1"></i>Clear Database
                 </button>
@@ -366,7 +366,7 @@
         <div class="modal-content bg-dark text-light">
             <div class="modal-header border-secondary">
                 <h5 class="modal-title"><i class="fas fa-info-circle me-2"></i>System Information</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div id="system-info-content" class="code-block" style="max-height: 500px;">
@@ -376,7 +376,7 @@
                 </div>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
             </div>
         </div>
     </div>

--- a/templates/core/equipment_conditional_fields_settings.html
+++ b/templates/core/equipment_conditional_fields_settings.html
@@ -33,7 +33,7 @@
     {% for message in messages %}
     <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
         {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     </div>
     {% endfor %}
 </div>
@@ -175,7 +175,7 @@
                     <i class="fas fa-plus me-2"></i>
                     Add Conditional Field Assignment
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <form method="post">
                 {% csrf_token %}
@@ -239,7 +239,7 @@
                      </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                     <button type="submit" class="btn btn-primary">Create Assignment</button>
                 </div>
             </form>

--- a/templates/core/locations_settings.html
+++ b/templates/core/locations_settings.html
@@ -952,7 +952,7 @@ $(document).ready(function() {
                 if (response.message) {
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                 }
                 location.reload();
@@ -1017,7 +1017,7 @@ $(document).ready(function() {
                 if (response.message) {
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                 }
                 location.reload();
@@ -1104,7 +1104,7 @@ $(document).ready(function() {
                 if (response.message) {
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                 }
                 location.reload();
@@ -1164,7 +1164,7 @@ $(document).ready(function() {
                 if (response.message) {
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                 }
                 location.reload();
@@ -1216,7 +1216,7 @@ $(document).ready(function() {
                 if (response.message) {
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                 }
                 location.reload();
@@ -1288,7 +1288,7 @@ $(document).ready(function() {
                     // Show success message
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(5000).fadeOut();
                     
                     // Reload page after a short delay to show new PODs
@@ -1345,7 +1345,7 @@ $(document).ready(function() {
                     // Show success message
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(5000).fadeOut();
                     
                     // Reload page after a short delay to show new MDCs
@@ -1412,7 +1412,7 @@ $(document).ready(function() {
                     $output.show();
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(5000).fadeOut();
                     setTimeout(function() { location.reload(); }, 2000);
                 } else {
@@ -1508,7 +1508,7 @@ $(document).ready(function() {
                     // Show success message
                     $('<div class="alert alert-success alert-dismissible fade show" role="alert">' +
                       response.message +
-                      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
+                      '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>' +
                       '</div>').prependTo('.locations-header').delay(3000).fadeOut();
                     
                     // Reset form

--- a/templates/core/settings.html
+++ b/templates/core/settings.html
@@ -477,7 +477,7 @@
                     <i class="fas fa-database text-primary me-2"></i>
                     Populate Comprehensive Demo Data
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-info">
@@ -532,7 +532,7 @@
                 </form>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-primary" onclick="populateDemoData()">
                     <i class="fas fa-database me-1"></i>Populate Demo Data
                 </button>
@@ -550,7 +550,7 @@
                     <i class="fas fa-exclamation-triangle text-danger me-2"></i>
                     Clear Database (DANGER ZONE)
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-danger">
@@ -593,7 +593,7 @@
                 </div>
             </div>
             <div class="modal-footer border-secondary">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" id="executeClearBtn" disabled>
                     <i class="fas fa-trash-alt me-1"></i>Clear Database
                 </button>

--- a/templates/core/system_health.html
+++ b/templates/core/system_health.html
@@ -172,7 +172,7 @@ function showDebugMessage(message, type = 'info') {
     messageDiv.className = `alert alert-${type === 'error' ? 'danger' : type === 'success' ? 'success' : 'info'} alert-dismissible fade show`;
     messageDiv.innerHTML = `
         ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span></button>
     `;
     
     debugDiv.appendChild(messageDiv);

--- a/templates/equipment/category_fields_management.html
+++ b/templates/equipment/category_fields_management.html
@@ -33,7 +33,7 @@
     {% for message in messages %}
     <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
         {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     </div>
     {% endfor %}
 </div>
@@ -214,7 +214,7 @@
                     <i class="fas fa-edit me-2"></i>
                     Edit Custom Field
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <form id="editFieldForm" method="post">
                 {% csrf_token %}
@@ -258,7 +258,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                     <button type="submit" class="btn btn-primary">Save Changes</button>
                 </div>
             </form>
@@ -275,7 +275,7 @@
                     <i class="fas fa-exclamation-triangle me-2"></i>
                     Confirm Delete
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <div class="modal-body">
                 <p>Are you sure you want to delete the custom field <strong id="delete_field_label"></strong>?</p>
@@ -285,7 +285,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <form id="deleteFieldForm" method="post" style="display: inline;">
                     {% csrf_token %}
                     <input type="hidden" name="action" value="delete_field">

--- a/templates/equipment/equipment_components.html
+++ b/templates/equipment/equipment_components.html
@@ -105,8 +105,8 @@
                                     <td>
                                         <div class="btn-group btn-group-sm">
                                             <button type="button" class="btn btn-outline-primary" 
-                                                    data-bs-toggle="modal" 
-                                                    data-bs-target="#componentModal{{ component.id }}">
+                                                    data-toggle="modal" 
+                                                    data-target="#componentModal{{ component.id }}">
                                                 <i class="fas fa-eye"></i>
                                             </button>
                                             <a href="#" class="btn btn-outline-secondary">
@@ -186,7 +186,7 @@
                     <i class="fas fa-puzzle-piece me-2"></i>
                     {{ component.name }}
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span></button>
             </div>
             <div class="modal-body">
                 <div class="row">
@@ -252,7 +252,7 @@
                 {% endif %}
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 <a href="#" class="btn btn-primary">Edit Component</a>
             </div>
         </div>

--- a/templates/equipment/location_select.html
+++ b/templates/equipment/location_select.html
@@ -152,21 +152,21 @@
 
 /* Bootstrap dark theme override */
 .bg-dark .location-select,
-[data-bs-theme="dark"] .location-select {
+.theme-dark .location-select {
     background-color: #2d3748;
     border-color: #4a5568;
     color: #e2e8f0;
 }
 
 .bg-dark .location-select option,
-[data-bs-theme="dark"] .location-select option {
+.theme-dark .location-select option {
     background-color: #2d3748;
     color: #e2e8f0;
     border-bottom: 1px solid #4a5568;
 }
 
 .bg-dark .location-select option[data-level="0"],
-[data-bs-theme="dark"] .location-select option[data-level="0"] {
+.theme-dark .location-select option[data-level="0"] {
     background-color: #1a202c;
     color: #f7fafc;
     border-bottom: 2px solid #4a5568;
@@ -174,27 +174,27 @@
 }
 
 .bg-dark .location-select option[data-level="1"],
-[data-bs-theme="dark"] .location-select option[data-level="1"] {
+.theme-dark .location-select option[data-level="1"] {
     background-color: #2d3748;
     color: #e2e8f0;
     padding-left: 20px;
 }
 
 .bg-dark .location-select option[data-level="2"],
-[data-bs-theme="dark"] .location-select option[data-level="2"] {
+.theme-dark .location-select option[data-level="2"] {
     background-color: #2d3748;
     color: #a0aec0;
     padding-left: 40px;
 }
 
 .bg-dark .location-select option:hover,
-[data-bs-theme="dark"] .location-select option:hover {
+.theme-dark .location-select option:hover {
     background-color: #4a5568 !important;
     color: #f7fafc !important;
 }
 
 .bg-dark .location-select option:checked,
-[data-bs-theme="dark"] .location-select option:checked {
+.theme-dark .location-select option:checked {
     background-color: #3182ce !important;
     color: #ffffff !important;
 }
@@ -206,7 +206,7 @@
 }
 
 .bg-dark .location-select:focus,
-[data-bs-theme="dark"] .location-select:focus {
+.theme-dark .location-select:focus {
     border-color: #63b3ed;
     box-shadow: 0 0 0 0.2rem rgba(99, 179, 237, 0.25);
 }
@@ -217,14 +217,14 @@
 }
 
 .bg-dark #site-filter,
-[data-bs-theme="dark"] #site-filter {
+.theme-dark #site-filter {
     background-color: #2d3748;
     border-color: #4a5568;
     color: #e2e8f0;
 }
 
 .bg-dark #site-filter option,
-[data-bs-theme="dark"] #site-filter option {
+.theme-dark #site-filter option {
     background-color: #2d3748;
     color: #e2e8f0;
 }
@@ -274,7 +274,7 @@ $(document).ready(function() {
     // Auto-detect dark mode and apply styles
     function applyDarkModeStyles() {
         const isDarkMode = $('body').hasClass('bg-dark') || 
-                          $('html').attr('data-bs-theme') === 'dark' ||
+                          document.body.classList.contains('theme-dark') ||
                           window.matchMedia('(prefers-color-scheme: dark)').matches;
         
         if (isDarkMode) {


### PR DESCRIPTION
App is Bootstrap 4.6.2 but several templates used BS5 attributes, silently breaking modals + dismiss buttons. Swept `data-bs-toggle/target/dismiss` → `data-toggle/target/dismiss` and `btn-close` → BS4 `.close` (+ × glyph) across equipment_components (edit modal never opened), category-fields, conditional-fields, debug, settings, custom-fields, locations/system-health. Also fixed dashboard_settings tooltip attrs and location_select's `[data-bs-theme=dark]` → `.theme-dark` (so dark styling applies). branding_settings.html left for the overhaul rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)