### PR TITLE
fix(map): show site-level equipment (was invisible)

### DIFF
--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -251,27 +251,53 @@ def _build_site_layout(site):
     # positioned here. Empty grid cells are allowed → the map mirrors the site.
     POD_W, POD_H = 250, 210
     auto_cols = max(1, int((canvas_w - PAD) // (POD_W + PAD)))
-    cells, ncols = assign_cells([(p.grid_row, p.grid_col) for p in pods], auto_cols)
+
+    # Each block is a real POD plus, if needed, a synthetic "Site-level" block for
+    # equipment NOT captured by any POD — attached directly to the site, or under
+    # an inactive direct child not shown as a POD. Without this it was invisible.
+    blocks = [{'pod': p, 'gr': p.grid_row, 'gc': p.grid_col} for p in pods]
+
+    rendered_loc_ids = set()
+    for p in pods:
+        rendered_loc_ids.add(p.id)
+        stack = [p.id]
+        while stack:
+            for ch in children_by_loc.get(stack.pop(), []):
+                rendered_loc_ids.add(ch.id)
+                stack.append(ch.id)
+    orphan_eq = [e for e in equipment if e.location_id not in rendered_loc_ids]
+    if orphan_eq:
+        site_tiles = []
+        for g in category_groups(orphan_eq):
+            site_tiles.append({'id': None, 'name': g['name'], 'count': g['count'],
+                               'counts': g['counts'], 'equipment': g['equipment'],
+                               'equipment_groups': [], 'children': []})
+        blocks.append({'pod': None, 'gr': None, 'gc': None,
+                       'name': 'Site-level', 'tiles': site_tiles})
+
+    cells, ncols = assign_cells([(b['gr'], b['gc']) for b in blocks], auto_cols)
     nrows = max((r for (r, c) in cells), default=0) + 1
 
     # Center each block within its cell square (split the PAD gutter both sides).
     cx, cy = PAD // 2, PAD // 2
     pods_payload = []
-    for p, (r, c) in zip(pods, cells):
+    for b, (r, c) in zip(blocks, cells):
         px = PAD + c * (POD_W + PAD) + cx
         py = PAD + r * (POD_H + PAD) + cy
-        mdcs_payload = []
-        for (loc, node) in build_pod_tiles(p):
-            mdcs_payload.append({
+        if b['pod'] is not None:
+            block_id, block_name = b['pod'].id, b['pod'].name
+            mdcs_payload = [{
                 'id': (loc.id if loc is not None else None),
                 'name': node['name'],
                 'count': node['count'], 'counts': node['counts'],
                 'equipment': node.get('equipment', []),
                 'equipment_groups': node.get('equipment_groups', []),
                 'children': node.get('children', []),
-            })
+            } for (loc, node) in build_pod_tiles(b['pod'])]
+        else:
+            block_id, block_name, mdcs_payload = None, b['name'], b['tiles']
         pods_payload.append({
-            'id': p.id, 'name': p.name, 'row': r, 'col': c,
+            'id': block_id, 'name': block_name, 'row': r, 'col': c,
             'x': round(px, 1), 'y': round(py, 1), 'w': POD_W, 'h': POD_H,
             'mdcs': mdcs_payload,
         })

--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -49,6 +49,7 @@
     display: flex; flex-direction: column; overflow: hidden;
     transition: left .15s ease, top .15s ease; }
 .pod-zone.dragging { transition: none; }  /* dragged block follows the pointer */
+.pod-synthetic { border-style: dashed; background: rgba(66,153,225,0.06); }  /* site-level catch-all */
 .pod-header { flex: 0 0 auto; padding: 5px 10px; font-size: 12px; font-weight: 700;
     color: #e2e8f0; border-bottom: 1px solid #4a5568;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -433,14 +434,15 @@
     layout.pods.forEach(function (pod) {
         var zone = document.createElement('div');
         zone.className = 'pod-zone';
-        zone.dataset.id = pod.id;
+        if (pod.id != null) zone.dataset.id = pod.id;  // synthetic "Site-level" block has no id
+        else zone.classList.add('pod-synthetic');
         zone.style.left = pod.x + 'px'; zone.style.top = pod.y + 'px';
         zone.style.width = pod.w + 'px'; zone.style.height = pod.h + 'px';
         var ph = document.createElement('div');
         ph.className = 'pod-header';
         ph.textContent = pod.name;
         ph.addEventListener('pointerdown', function (e) {
-            if (editing) beginDrag(e, [zone]);  // moving the block moves its tiles (they're children)
+            if (editing && pod.id != null) beginDrag(e, [zone]);  // real PODs only; site block stays put
         });
         zone.appendChild(ph);
 


### PR DESCRIPTION
Equipment attached directly to the **site** (or under an inactive direct-child not rendered as a POD) was dropped by the map builder. Now it's surfaced in a synthetic **"Site-level"** block (dashed border), category-grouped like POD-direct equipment, auto-placed on the grid. The block isn't draggable/saveable (no id), but its chips support **Move** so you can relocate that gear into a POD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)