### PR TITLE
feat(map): allow zoom up to 200%

### DIFF
--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -181,7 +181,7 @@
         {% if selected_site %}
         <div class="zoom-control">
             <label class="me-1"><i class="fas fa-search"></i> Zoom:</label>
-            <input type="range" id="zoomRange" min="30" max="150" step="5" value="100" title="Scale the map">
+            <input type="range" id="zoomRange" min="30" max="200" step="5" value="100" title="Scale the map">
             <span id="zoomPct">100%</span>
             <button type="button" id="zoomFitBtn" class="btn btn-outline-light btn-sm" title="Fit to width">Fit</button>
         </div>


### PR DESCRIPTION
Raise the map zoom slider max from 150% → 200% (the scale logic already clamped at 2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)