### PR TITLE
fix(deploy): self-heal targets real equipment 0023 migration name

### DIFF
--- a/scripts/deployment/docker-entrypoint.sh
+++ b/scripts/deployment/docker-entrypoint.sh
@@ -326,7 +326,7 @@ try:
         # Check for common problematic migrations
         problematic_migrations = [
             ('core', '0020_brandingsettings_table_hover_background_color_and_more'),
-            ('equipment', '0021_equipmentissue_issuetag_and_more'),
+            ('equipment', '0023_equipmentissue_issuetag_and_more'),
         ]
         
         fixed_any = False


### PR DESCRIPTION
The deploy entrypoint already self-heals `DuplicateTable` by inserting a `django_migrations` row when the tables exist — but its list referenced the phantom name `0021_equipmentissue_issuetag_and_more`. So when the newly-committed `0023_equipmentissue_issuetag_and_more` (#198) hit DuplicateTable on dev/prod (tables already created out-of-band), the heal faked the wrong name and 0023 stayed **unapplied**. Pointed the heal at the real `0023` name → it records 0023 (tables verified present) and re-migrates clean. Fresh DBs still apply it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)