### PR TITLE
fix(mobile): calendar-first + compact map legend & equipment header

### DIFF
--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -111,6 +111,17 @@
     color: #e2e8f0; padding: 7px 10px; font-size: 13px; border-radius: 4px; cursor: pointer; white-space: nowrap; }
 .ctx-menu button:hover { background: #2a3550; }
 .dragging { opacity:.85; z-index:40 !important; }
+
+/* Mobile: tighten the header so the map gets the space, shrink the legend. */
+@media (max-width: 768px) {
+    .map-header { padding: 10px 12px; margin-bottom: 12px; }
+    .map-controls { gap: 8px; }
+    .map-legend { gap: 6px 10px; margin-left: 0; width: 100%; }
+    .legend-item { font-size: 10px; gap: 4px; }
+    .legend-swatch { width: 10px; height: 10px; }
+    .zoom-control input[type=range] { width: 90px; }
+    #canvasWrap { max-height: 70vh; }
+}
 </style>
 {% endblock %}
 

--- a/templates/equipment/equipment_list.html
+++ b/templates/equipment/equipment_list.html
@@ -198,13 +198,15 @@
 /* Compact mobile filters: hide redundant labels, search on its own row,
    dropdowns flow across one row. */
 @media (max-width: 768px) {
-    .equipment-header { padding: 8px 12px; }
-    .equipment-filters { gap: 8px; }
-    .filter-group { flex: 1 1 30%; }
-    .filter-group.filter-search { flex-basis: 100%; }
+    .equipment-header { padding: 8px 10px; margin-bottom: 10px; }
+    .equipment-header h5 { font-size: 1rem; }
+    .equipment-filters { gap: 6px; }
+    /* search full-width on its own row; the three dropdowns share one tight row */
+    .filter-group { flex: 1 1 0; min-width: 0; }
+    .filter-group.filter-search { flex: 1 1 100%; }
     .filter-group label { display: none; }
-    .filter-select, .search-input { min-width: 0; width: 100%; }
-    .action-buttons { margin-left: auto; }
+    .filter-select, .search-input { min-width: 0; width: 100%; padding: 6px 8px; }
+    .action-buttons { flex: 0 0 auto; margin-left: auto; }
 }
 </style>
 {% endblock %}

--- a/templates/events/calendar.html
+++ b/templates/events/calendar.html
@@ -771,6 +771,25 @@
     background-color: #2d3748;
     color: white;
 }
+
+/* Mobile: the calendar is the point — show it right after the header, push the
+   legend/filters below it, and keep the legend a compact wrapping row (not a tall
+   vertical stack) so it doesn't bury the calendar. */
+@media (max-width: 768px) {
+    .calendar-container { display: flex; flex-direction: column; }
+    .calendar-header { order: 0; }
+    .calendar-content { order: 1; }
+    .controls-section { order: 2; }
+
+    /* keep the legend horizontal + compact instead of one-per-line */
+    .filters-and-legend { flex-direction: row; flex-wrap: wrap; align-items: center; }
+    .legend-compact .legend-items,
+    .legend-items { flex-direction: row !important; flex-wrap: wrap; gap: 6px 10px !important; }
+    .legend-item { padding: 2px 6px !important; font-size: 11px !important; }
+    .legend-color { width: 11px; height: 11px; }
+
+    .calendar-content { min-height: 60vh; }
+}
 </style>
 {% endblock %}
 


### PR DESCRIPTION
Mobile responsive polish from device testing:
- **Calendar** (worst offender): reorder so the calendar renders right after the header with the legend/filters **below** it, and keep the legend a compact wrapping row instead of a tall vertical stack — you no longer scroll past controls to reach the calendar.
- **Map**: shrink the oversized legend (smaller font/swatches, drop the full-width gap) and tighten header padding on phones.
- **Equipment list**: tighter header + the three filter dropdowns share one equal-thirds row (search full-width above) so the top block isn't so blocky.

(Maintenance Activities / Activities pages were already fine per testing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)