### PR TITLE
fix(maintenance): allow logging activities against inactive/off-site equipment

### DIFF
--- a/maintenance/forms.py
+++ b/maintenance/forms.py
@@ -635,19 +635,22 @@ class MaintenanceActivityForm(forms.ModelForm):
                     except (Location.DoesNotExist, ValueError):
                         pass
         
-        # If equipment_id is provided (from URL parameter), ensure it's included in queryset
-        # even if site filtering would exclude it
+        # Always include explicitly-selected equipment in the choices — even if it
+        # is inactive or outside the current site filter. The map / calendar /
+        # equipment list show ALL equipment (is_active no longer filtered), so a
+        # user can select an inactive item to log an activity against; the dropdown
+        # otherwise lists active equipment only.
+        include_ids = set()
         if equipment_id:
-            try:
-                equipment = Equipment.objects.get(id=equipment_id, is_active=True)
-                # Check if equipment is already in queryset
-                if not equipment_queryset.filter(id=equipment_id).exists():
-                    # Add it to the queryset using union
-                    from django.db.models import Q
-                    equipment_queryset = equipment_queryset | Equipment.objects.filter(id=equipment_id, is_active=True)
-            except (Equipment.DoesNotExist, ValueError):
-                pass
-        
+            include_ids.add(str(equipment_id))
+        if self.is_bound:
+            if hasattr(self.data, 'getlist'):
+                include_ids.update(self.data.getlist('equipment'))
+            include_ids.add(self.data.get('equipment'))
+        include_ids = {i for i in include_ids if i}
+        if include_ids:
+            equipment_queryset = (equipment_queryset | Equipment.objects.filter(id__in=include_ids)).distinct()
+
         self.fields['equipment'].queryset = equipment_queryset.select_related('category')
         
         self.fields['activity_type'].queryset = MaintenanceActivityType.objects.filter(is_active=True).select_related('category')


### PR DESCRIPTION
**Bug:** creating a maintenance activity (incl. bulk-create from the calendar) failed — `Select a valid choice. That choice is not one of the available choices` + `At least 1 equipment is required` — for equipment that's inactive or outside the selected-site filter. But the map/calendar/equipment list all show **all** equipment now, so users can select those items.

**Fix:** `MaintenanceActivityForm` now always includes the explicitly submitted/passed equipment id(s) in its field queryset (regardless of `is_active` or site filter), so validation accepts them. The dropdown still lists active equipment by default. This also unblocks the calendar, which showed no activities because none could be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)