### PR TITLE
fix(calendar): remove redundant Add Maintenance Activity button

### DIFF
--- a/templates/events/calendar.html
+++ b/templates/events/calendar.html
@@ -813,11 +813,6 @@
             </div>
             
             <div class="d-flex align-items-center gap-2">
-                
-                <button type="button" class="btn btn-outline-success btn-sm" onclick="openCreateMaintenanceModal()">
-                    <i class="fas fa-tools"></i>
-                    Add Maintenance Activity
-                </button>
                 <a href="{% url 'events:calendar_settings' %}" class="btn btn-outline-light btn-sm">
                     <i class="fas fa-cog"></i> Settings
                 </a>


### PR DESCRIPTION
Clicking a date already opens the create flow, so the header button was redundant. Removed it; Settings stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)