### PR TITLE
feat(api/mcp): trigger Portainer stack redeploy via API + MCP

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -19,3 +19,22 @@ class HasApiReadAccess(BasePermission):
                     or profile.has_permission('administration.read'))
         except Exception:
             return False
+
+
+class HasApiDeployAccess(BasePermission):
+    """Privileged action permission — triggering a stack redeploy. Stricter than
+    read access: requires diagnostics.deploy / administration.write / staff."""
+    message = 'You need diagnostics.deploy or administration write access to redeploy.'
+
+    def has_permission(self, request, view):
+        user = getattr(request, 'user', None)
+        if not (user and user.is_authenticated):
+            return False
+        if user.is_superuser or user.is_staff:
+            return True
+        try:
+            profile = user.userprofile
+            return (profile.has_permission('diagnostics.deploy')
+                    or profile.has_permission('administration.write'))
+        except Exception:
+            return False

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('', views.ApiRoot.as_view(), name='root'),
     path('diagnostics/health/', views.DiagnosticsHealth.as_view(), name='diag_health'),
     path('diagnostics/summary/', views.DiagnosticsSummary.as_view(), name='diag_summary'),
+    path('actions/redeploy/', views.RedeployView.as_view(), name='redeploy'),
     path('data/<str:app_label>/<str:model_name>/', views.ModelListView.as_view(), name='model_list'),
     path('data/<str:app_label>/<str:model_name>/<int:pk>/', views.ModelDetailView.as_view(), name='model_detail'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -8,7 +8,7 @@ from rest_framework.pagination import PageNumberPagination
 
 from .registry import exposed_models, get_model, model_key, field_metadata, safe_field_names
 from .serializers import build_serializer
-from .permissions import HasApiReadAccess
+from .permissions import HasApiReadAccess, HasApiDeployAccess
 
 
 class ApiPagination(PageNumberPagination):
@@ -133,3 +133,27 @@ class DiagnosticsSummary(APIView):
                 'scheduled_end': a.scheduled_end.isoformat() if a.scheduled_end else None,
             } for a in overdue[:25]],
         })
+
+
+class RedeployView(APIView):
+    """Trigger a Portainer GitOps stack redeploy. Reuses the existing webhook
+    configured on the Webhook Settings page (PortainerConfig) — the same path as
+    the 'Update Stack' button. Privileged: requires diagnostics.deploy /
+    administration.write / staff. Every call is logged."""
+    permission_classes = [HasApiDeployAccess]
+
+    def get(self, request):
+        from core.models import PortainerConfig
+        cfg = PortainerConfig.get_config()
+        return Response({'configured': bool(cfg.portainer_url),
+                         'stack_name': cfg.stack_name or None,
+                         'usage': 'POST here to trigger a Portainer stack redeploy.'})
+
+    def post(self, request):
+        import logging
+        from core.views.helpers import trigger_portainer_stack_update
+        logging.getLogger(__name__).warning(
+            "Stack redeploy triggered via API by user=%s", getattr(request.user, 'username', '?'))
+        result = trigger_portainer_stack_update()
+        ok = 'successfully' in result.lower() or 'triggered' in result.lower()
+        return Response({'success': ok, 'message': result}, status=200 if ok else 502)

--- a/core/rbac.py
+++ b/core/rbac.py
@@ -148,6 +148,7 @@ def initialize_default_permissions():
 
         # Diagnostics / API permission (read-only programmatic access — AI agent)
         ('diagnostics.read', 'Diagnostics Read', 'Read-only access to system diagnostics and the dynamic API', 'administration'),
+        ('diagnostics.deploy', 'Diagnostics Deploy', 'Trigger a Portainer stack redeploy via the API/MCP', 'administration'),
         
         # Events permissions  
         ('events.read', 'Events Read', 'View calendar events and schedules', 'events'),
@@ -224,7 +225,7 @@ def initialize_default_permissions():
             'display_name': 'Administrator',
             'description': 'Full system access with all permissions',
             'is_system_role': True,
-            'permissions': ['admin.full_access']
+            'permissions': ['admin.full_access', 'diagnostics.deploy']
         },
         {
             'name': 'manager',
@@ -308,7 +309,7 @@ def initialize_default_permissions():
                 'site_map.read', 'site_map.write',
                 'maintenance_calendar.read', 'maintenance_calendar.write',
                 'administration.read', 'administration.write',
-                'admin.full_access'
+                'admin.full_access', 'diagnostics.deploy'
             ]
         }
     ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@ Access requires `diagnostics.read` (granted by the `ai_diagnostics` role) or
 | GET | `/api/v1/data/<app>/<model>/<pk>/` | Single record. |
 | GET | `/api/v1/diagnostics/health/` | Comprehensive system health (db, cache, celery worker/beat, email, system). |
 | GET | `/api/v1/diagnostics/summary/` | Open/critical issues, overdue maintenance, equipment-by-status. |
+| GET/POST | `/api/v1/actions/redeploy/` | GET: is a redeploy configured. **POST: trigger a Portainer GitOps stack redeploy** (re-pull + recreate). Privileged — requires `diagnostics.deploy` / `administration.write` / staff. Uses the webhook from the Webhook Settings page (`PortainerConfig`). |
 
 Every record includes a `display` field (the model's `__str__`) for readability.
 

--- a/mcp/maintenance-dashboard/README.md
+++ b/mcp/maintenance-dashboard/README.md
@@ -15,6 +15,8 @@ the Maintenance Dashboard deployment through its **read-only** dynamic API
 | `equipment_status()` | Fleet counts grouped by status |
 | `list_models()` | Discover every model the API exposes + its fields |
 | `query_model(app, model, filters, ordering, page_size)` | Ad-hoc query against any reflected model |
+| `redeploy_status()` | Whether a Portainer stack redeploy is configured |
+| `trigger_redeploy()` | **Privileged** — trigger a Portainer GitOps stack redeploy (needs `diagnostics.deploy`) |
 
 ## Setup
 

--- a/mcp/maintenance-dashboard/server.py
+++ b/mcp/maintenance-dashboard/server.py
@@ -51,6 +51,24 @@ def _get(path: str, params: dict | None = None):
         return {"error": f"Request failed: {e}"}
 
 
+def _post(path: str, json_body: dict | None = None):
+    """POST a path under /api/v1 (privileged actions) and return parsed JSON."""
+    try:
+        with _client() as c:
+            resp = c.post(path, json=json_body or {})
+        if resp.status_code == 401:
+            return {"error": "Unauthorized — check MAINT_API_TOKEN."}
+        if resp.status_code == 403:
+            return {"error": "Forbidden — the token's account lacks the required permission."}
+        # 200/202/502 all carry a JSON body we want to surface
+        try:
+            return resp.json()
+        except ValueError:
+            return {"error": f"Unexpected response: {resp.status_code}"}
+    except httpx.HTTPError as e:
+        return {"error": f"Request failed: {e}"}
+
+
 @mcp.tool()
 def get_system_health() -> dict:
     """Comprehensive system health: database, cache, Celery worker/beat, email, system."""
@@ -97,6 +115,20 @@ def equipment_status() -> dict:
             "equipment_by_status": summary.get("equipment_by_status", {}),
         }
     return summary
+
+
+@mcp.tool()
+def redeploy_status() -> dict:
+    """Whether a stack redeploy is configured (Portainer webhook set) + the stack name."""
+    return _get("/actions/redeploy/")
+
+
+@mcp.tool()
+def trigger_redeploy() -> dict:
+    """Trigger a Portainer GitOps stack redeploy (re-pull + recreate the stack).
+    PRIVILEGED — the token's account needs diagnostics.deploy / admin. Uses the
+    webhook configured on the dashboard's Webhook Settings page."""
+    return _post("/actions/redeploy/")
 
 
 @mcp.tool()


### PR DESCRIPTION
Links the existing Portainer GitOps webhook (configured on the **Webhook Settings** page → `PortainerConfig`) into the API + MCP so the AI agent can redeploy the stack.

- **`POST /api/v1/actions/redeploy/`** — triggers a stack re-pull + recreate via the existing `trigger_portainer_stack_update()` (same path as the "Update Stack" button). `GET` reports whether it's configured + the stack name.
- **`HasApiDeployAccess`** — privileged: `diagnostics.deploy` / `administration.write` / staff (stricter than the read-only diagnostics access). Every call is logged.
- New **`diagnostics.deploy`** RBAC permission, granted to **admin** + **admin_user** roles (not viewers/managers, not the read-only `ai_diagnostics` agent by default — grant it explicitly if you want the agent to deploy).
- **MCP tools:** `redeploy_status()` + `trigger_redeploy()`.
- Reuses the existing webhook config — **no new secret or env var**.

Verified: check clean, URL resolves, permission imports, server compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)