### PR TITLE
fix(core): correct .models imports in views package (ModuleNotFoundError)

### DIFF
--- a/core/views/health.py
+++ b/core/views/health.py
@@ -587,7 +587,7 @@ def database_stats(request):
     try:
         from django.db import connection
         from django.db.models import Count
-        from .models import Location, Customer
+        from core.models import Location, Customer
         from equipment.models import Equipment
         from maintenance.models import MaintenanceActivity
         from events.models import CalendarEvent

--- a/core/views/helpers.py
+++ b/core/views/helpers.py
@@ -322,7 +322,7 @@ def trigger_portainer_stack_update():
     """Trigger a stack update by calling the webhook URL."""
     logger.info("=== TRIGGER PORTAINER STACK UPDATE STARTED ===")
     try:
-        from .models import PortainerConfig
+        from core.models import PortainerConfig
         config = PortainerConfig.get_config()
         
         webhook_url = config.portainer_url
@@ -378,7 +378,7 @@ def test_portainer_connection():
     """Test connection to webhook URL."""
     logger.info("=== TEST WEBHOOK CONNECTION STARTED ===")
     try:
-        from .models import PortainerConfig
+        from core.models import PortainerConfig
         config = PortainerConfig.get_config()
         
         webhook_url = config.portainer_url

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -958,7 +958,7 @@ def export_sites_csv(request):
     ])
     
     # Get sites data (locations marked as sites)
-    from .models import Location
+    from core.models import Location
     sites = Location.objects.filter(is_site=True).order_by('name')
     
     # Write data rows
@@ -998,7 +998,7 @@ def import_sites_csv(request):
         header = next(csv_data)
         
         # Import data
-        from .models import Location
+        from core.models import Location
         
         imported_count = 0
         error_count = 0
@@ -1118,7 +1118,7 @@ def export_locations_csv(request):
     ])
     
     # Get all locations
-    from .models import Location
+    from core.models import Location
     locations = Location.objects.select_related('parent_location').order_by('name')
     
     # Apply site filter if provided
@@ -1169,7 +1169,7 @@ def import_locations_csv(request):
         header = next(csv_data)
         
         # Import data
-        from .models import Location
+        from core.models import Location
         
         imported_count = 0
         error_count = 0

--- a/core/views/webhooks.py
+++ b/core/views/webhooks.py
@@ -47,7 +47,7 @@ from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
 @user_passes_test(is_staff_or_superuser)
 def webhook_settings(request):
     """Webhook management settings page."""
-    from .models import PortainerConfig
+    from core.models import PortainerConfig
     
     # Add comprehensive debugging
     logger.info(f"=== WEBHOOK SETTINGS DEBUG ===")


### PR DESCRIPTION
`/webhook-settings/` threw `ModuleNotFoundError: No module named 'core.views.models'`. After the views split, 8 in-function imports still used `from .models import …` (now resolves to `core.views.models`, which doesn't exist). Fixed to `from core.models import …` across health.py, helpers.py, locations.py, webhooks.py. This also unbreaks the new API/MCP redeploy (helpers' `trigger_portainer_stack_update` used the bad import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)