### PR TITLE
fix(deploy): GitOps webhook calls bare URL (no stray ?tag=latest)

### DIFF
--- a/core/views/helpers.py
+++ b/core/views/helpers.py
@@ -343,12 +343,17 @@ def trigger_portainer_stack_update():
             headers['X-Webhook-Secret'] = webhook_secret
             logger.info("Added webhook secret to headers")
         
-        # Build webhook URL with tag parameter
-        webhook_url_with_tag = f"{webhook_url}?tag={image_tag}"
-        logger.info(f"Calling webhook URL with tag: {webhook_url_with_tag}")
-        
+        # For a Portainer GitOps (git-backed) stack, POST the bare webhook to trigger
+        # a git re-pull + redeploy. Only append ?tag=<tag> for image-based stacks
+        # that pin a specific (non-"latest") tag — a stray ?tag=latest makes Portainer
+        # attempt an image-tag update instead of pulling the latest git revision.
+        call_url = webhook_url
+        if image_tag and image_tag.strip().lower() not in ('', 'latest'):
+            call_url = f"{webhook_url}?tag={image_tag.strip()}"
+        logger.info(f"Calling webhook URL: {call_url}")
+
         webhook_response = requests.post(
-            webhook_url_with_tag,
+            call_url,
             headers=headers,
             json={'action': 'update_stack', 'timestamp': time.time()},
             timeout=30


### PR DESCRIPTION
The webhook fires (Portainer returns 204) but the stack doesn't update. Cause: `trigger_portainer_stack_update` always appended `?tag=latest`, which tells Portainer to do an **image-tag update** rather than re-pulling the latest **git** revision on a GitOps (git-backed) stack. Now it POSTs the **bare** webhook (the canonical GitOps redeploy); `?tag=` is only appended for image-based stacks pinned to a specific non-`latest` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)