### PR TITLE
feat(webhooks): auto-detected Deployment Status on settings page

### DIFF
--- a/core/views/webhooks.py
+++ b/core/views/webhooks.py
@@ -43,12 +43,85 @@ from django.utils import timezone
 from .helpers import *  # noqa: F401,F403 (shared helpers + globals)
 
 
+def get_deployment_status(config):
+    """Collect as much deployment detail as possible automatically: the running
+    app version, the parsed Portainer endpoint/stack-webhook id, config timestamps,
+    and — when Portainer API credentials are configured — live stack details
+    (name, status, git ref/commit, last update). All best-effort."""
+    import json as _json
+    from urllib.parse import urlparse
+
+    status = {'version': {}, 'portainer': {}, 'stack': None, 'errors': []}
+
+    # Running app version (from version.json — always available)
+    try:
+        vf = settings.BASE_DIR / 'version.json'
+        if vf.exists():
+            with open(vf) as f:
+                vi = _json.load(f)
+            status['version'] = {
+                'version': vi.get('version'), 'full': vi.get('full_version'),
+                'commit': vi.get('commit_hash'), 'branch': vi.get('branch'),
+                'date': vi.get('commit_date'), 'count': vi.get('commit_count'),
+            }
+    except Exception as e:
+        status['errors'].append(f'version: {e}')
+
+    url = (config.portainer_url or '').strip()
+    if url:
+        p = urlparse(url)
+        base = f'{p.scheme}://{p.netloc}' if p.scheme else ''
+        wid = url.rstrip('/').split('/')[-1].split('?')[0]
+        status['portainer'] = {
+            'base': base,
+            'webhook_id': wid,
+            'image_tag': config.image_tag,
+            'polling': config.get_polling_frequency_display() if hasattr(config, 'get_polling_frequency_display') else config.polling_frequency,
+            'stack_name': config.stack_name or None,
+            'last_commit': (config.last_commit_hash or '')[:8] or None,
+            'last_commit_date': config.last_commit_date,
+            'last_check': config.last_check_date,
+            'has_api_creds': bool(config.portainer_user and config.portainer_password),
+        }
+        # Live Portainer stack details (only if API credentials are configured)
+        if config.portainer_user and config.portainer_password and base:
+            try:
+                jwt = requests.post(f'{base}/api/auth',
+                                    json={'username': config.portainer_user, 'password': config.portainer_password},
+                                    timeout=10).json().get('jwt')
+                if jwt:
+                    stacks = requests.get(f'{base}/api/stacks',
+                                          headers={'Authorization': f'Bearer {jwt}'}, timeout=10).json()
+                    match = None
+                    for s in (stacks or []):
+                        au = s.get('AutoUpdate') or {}
+                        if au.get('Webhook') and au.get('Webhook') in url:
+                            match = s
+                            break
+                        if config.stack_name and s.get('Name') == config.stack_name:
+                            match = s
+                    if match:
+                        git = match.get('GitConfig') or {}
+                        status['stack'] = {
+                            'id': match.get('Id'),
+                            'name': match.get('Name'),
+                            'status': 'active' if match.get('Status') == 1 else 'inactive',
+                            'git_url': git.get('URL'),
+                            'git_ref': (git.get('ReferenceName') or '').replace('refs/heads/', '') or None,
+                            'git_commit': (git.get('ConfigHash') or '')[:8] or None,
+                            'update_date': match.get('UpdateDate'),
+                        }
+            except Exception as e:
+                status['errors'].append(f'portainer api: {e}')
+    return status
+
+
 @login_required
 @user_passes_test(is_staff_or_superuser)
 def webhook_settings(request):
     """Webhook management settings page."""
     from core.models import PortainerConfig
-    
+
     # Add comprehensive debugging
     logger.info(f"=== WEBHOOK SETTINGS DEBUG ===")
     logger.info(f"Request method: {request.method}")
@@ -281,6 +354,7 @@ def webhook_settings(request):
         'polling_frequency': config.polling_frequency,
         'polling_choices': config.POLLING_CHOICES,
         'webhook_secret': webhook_secret,
+        'deployment_status': get_deployment_status(config),
         'debug_info': {
             'url_exists': bool(config.portainer_url),
             'stack_exists': bool(config.stack_name),

--- a/templates/core/webhook_settings.html
+++ b/templates/core/webhook_settings.html
@@ -654,7 +654,55 @@
             Portainer Integration
         </h2>
         <p class="text-muted mb-0">Configure your Django app to connect to Portainer and trigger stack updates</p>
-        
+
+        <!-- Auto-detected deployment status -->
+        {% with ds=deployment_status %}
+        <div class="card bg-dark text-light mt-4 mb-2" style="border:1px solid #2d3748;">
+            <div class="card-header" style="background:#0f1419;">
+                <i class="fas fa-info-circle me-2"></i>Deployment Status
+                <small class="text-muted">— auto-detected</small>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-4 mb-2">
+                        <h6 class="text-info mb-1"><i class="fas fa-code-branch me-1"></i>Running Build</h6>
+                        {% with v=ds.version %}
+                        <div><strong>{{ v.full|default:v.version|default:"unknown" }}</strong></div>
+                        <div class="text-muted small">branch <code>{{ v.branch|default:"?" }}</code> · commit <code>{{ v.commit|default:"?" }}</code></div>
+                        {% if v.date %}<div class="text-muted small">built {{ v.date }}</div>{% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="col-md-4 mb-2">
+                        <h6 class="text-info mb-1"><i class="fas fa-server me-1"></i>Portainer Endpoint</h6>
+                        {% with pt=ds.portainer %}
+                        {% if pt.base %}
+                        <div><a href="{{ pt.base }}" target="_blank" class="text-light">{{ pt.base }}</a></div>
+                        <div class="text-muted small">stack webhook <code>{{ pt.webhook_id|truncatechars:14 }}</code></div>
+                        <div class="text-muted small">image tag <code>{{ pt.image_tag|default:"latest" }}</code> · polling {{ pt.polling }}</div>
+                        <div class="text-muted small">API creds: {% if pt.has_api_creds %}<span class="text-success">set</span>{% else %}<span class="text-warning">not set</span>{% endif %}</div>
+                        {% else %}<div class="text-muted">No webhook URL configured yet.</div>{% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="col-md-4 mb-2">
+                        <h6 class="text-info mb-1"><i class="fas fa-layer-group me-1"></i>Stack</h6>
+                        {% with s=ds.stack pt=ds.portainer %}
+                        {% if s %}
+                        <div><strong>{{ s.name }}</strong>
+                            <span class="badge {% if s.status == 'active' %}badge-success{% else %}badge-secondary{% endif %}">{{ s.status }}</span></div>
+                        {% if s.git_ref %}<div class="text-muted small">git <code>{{ s.git_ref }}</code> @ <code>{{ s.git_commit|default:"?" }}</code></div>{% endif %}
+                        {% if s.update_date %}<div class="text-muted small">updated {{ s.update_date }}</div>{% endif %}
+                        {% else %}
+                        <div class="text-muted small">{% if pt.has_api_creds %}Stack not found via the Portainer API.{% else %}Add a Portainer API username/password below to auto-load live stack details (name, status, git ref/commit).{% endif %}</div>
+                        {% if pt.last_commit %}<div class="text-muted small mt-1">last deploy commit <code>{{ pt.last_commit }}</code>{% if pt.last_commit_date %} ({{ pt.last_commit_date }}){% endif %}</div>{% endif %}
+                        {% endif %}
+                        {% endwith %}
+                    </div>
+                </div>
+                {% if ds.errors %}<div class="text-warning small mt-2"><i class="fas fa-exclamation-triangle me-1"></i>{{ ds.errors|join:"; " }}</div>{% endif %}
+            </div>
+        </div>
+        {% endwith %}
+
         <!-- Quick Status Overview -->
         <div class="row mt-4">
             <div class="col-md-3">


### PR DESCRIPTION
Overhauls the webhook settings page to pull as much detail as possible **automatically**:
- **Running build** — version / branch / commit / build date from `version.json` (always).
- **Portainer endpoint** — base URL + stack-webhook id parsed from the configured webhook; image tag, polling, last-deploy commit/date from config.
- **Live stack details** — when Portainer API username+password are set, logs into the Portainer API and shows the matched stack's **name, status, git ref + commit, last update**.

Shown as a "Deployment Status" card at the top. Everything is best-effort and fails soft (no creds → just shows the version + endpoint, with a hint to add API creds for live stack details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)