### PR TITLE
fix(roles): align permission checkboxes with their labels

### DIFF
--- a/templates/core/roles_permissions_management.html
+++ b/templates/core/roles_permissions_management.html
@@ -194,6 +194,15 @@
     border-bottom: none;
 }
 
+.permission-check-item .form-check-input {
+    /* Bootstrap 4 makes .form-check-input position:absolute (for .form-check
+       containers). Here it's a flex child, so keep it in flow + aligned. */
+    position: static;
+    margin: 0 10px 0 0;
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+}
 .form-check-input {
     margin-right: 10px;
     background-color: #1a2238;


### PR DESCRIPTION
The permission checkboxes in the role add/edit modal were detached/offset from their labels. Cause: Bootstrap 4's `.form-check-input` is `position:absolute` (for `.form-check` containers); here it's a flex child, so BS4 pulled it out of flow. Scoped an override to keep it `position:static` + inline next to its label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)