### PR TITLE
fix(media): serve uploaded media in production (logo upload broken on prod)

### DIFF
--- a/maintenance_dashboard/urls.py
+++ b/maintenance_dashboard/urls.py
@@ -35,7 +35,15 @@ urlpatterns = [
     path('auth/reset/done/', auth_views.PasswordResetCompleteView.as_view(template_name='registration/password_reset_complete.html'), name='password_reset_complete'),
 ]
 
-# Serve media files during development
+# Serve uploaded media (branding logo/favicon, equipment docs) in ALL environments.
+# Django only auto-serves media under DEBUG, so on prod (DEBUG=False) uploaded logos
+# 404'd. Branding must load even on the (unauthenticated) login page, so serve it
+# via Django's static serve view regardless of DEBUG. (Static files are handled by
+# WhiteNoise in prod; the DEBUG block below covers static during local dev.)
+from django.urls import re_path
+from django.views.static import serve as _media_serve
+urlpatterns += [
+    re_path(r'^media/(?P<path>.*)$', _media_serve, {'document_root': settings.MEDIA_ROOT}),
+]
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Uploaded branding logo/favicon (and equipment docs) 404'd on prod: Django only auto-serves `/media/` under `DEBUG=True`, and prod has no proxy route for it. Branding also has to load on the unauthenticated login page. Now `/media/` is served via Django's static `serve` view in all environments (static files still go through WhiteNoise in prod). Fixes 'uploading logo on prod broken'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)